### PR TITLE
Inner types

### DIFF
--- a/R/base-coercion.R
+++ b/R/base-coercion.R
@@ -31,39 +31,18 @@ at_least_2D <- function(x, elem) {
 
 #' @export
 as.double.vctrs_rray <- function(x, ...) {
-
-  dim <- vec_dim(x)
-  to <- new_ptype_array(double(), dim)
-
-  new_array(
-    .data = vec_cast(vec_data(x), to),
-    dim = dim,
-    dimnames = dim_names(x)
-  )
+  x <- vec_data(x)
+  rray_cast_inner(x, double())
 }
 
 #' @export
 as.integer.vctrs_rray <- function(x, ...) {
-
-  dim <- vec_dim(x)
-  to <- new_ptype_array(integer(), dim)
-
-  new_array(
-    .data = vec_cast(vec_data(x), to),
-    dim = dim,
-    dimnames = dim_names(x)
-  )
+  x <- vec_data(x)
+  rray_cast_inner(x, integer())
 }
 
 #' @export
 as.logical.vctrs_rray <- function(x, ...) {
-
-  dim <- vec_dim(x)
-  to <- new_ptype_array(logical(), dim)
-
-  new_array(
-    .data = vec_cast(vec_data(x), to),
-    dim = dim,
-    dimnames = dim_names(x)
-  )
+  x <- vec_data(x)
+  rray_cast_inner(x, logical())
 }

--- a/R/compat-vctrs.R
+++ b/R/compat-vctrs.R
@@ -163,8 +163,8 @@ vec_type2.vctrs_rray.vctrs_unspecified <- function(x, y) x
 #' @method vec_type2.vctrs_rray vctrs_rray
 #' @export
 vec_type2.vctrs_rray.vctrs_rray <- function(x, y) {
-  inner_ptype <- vec_type2(vec_data(x), vec_data(y))
-  new_rray(inner_ptype, shape = rray_shape2(x, y))
+  inner_type <- rray_type_inner2(x, y)
+  new_rray(inner_type, shape = rray_shape2(x, y))
 }
 
 # vec_type2 vctrs_rray <-> double/matrix/array ---------------------------------

--- a/R/inner.R
+++ b/R/inner.R
@@ -1,0 +1,54 @@
+rray_type_inner <- function(x) {
+  vec_data(x)[0]
+}
+
+rray_type_inner2 <- function(x, y) {
+  vec_type2(rray_type_inner(x), rray_type_inner(y))
+}
+
+rray_type_inner_common <- function(..., .ptype = NULL) {
+
+  if (!vctrs::is_partial(.ptype)) {
+    return(rray_type_inner(.ptype))
+  }
+
+  args <- compact(list2(.ptype, ...))
+
+  if (length(args) == 0) {
+    ptype <- NULL
+  }
+  else if (length(args) == 1) {
+    ptype <- rray_type_inner(args[[1]])
+  }
+  else {
+    ptypes <- map(args, rray_type_inner)
+    ptype <- reduce(ptypes, rray_type_inner2)
+  }
+
+  vctrs::vec_type_finalise(ptype)
+}
+
+rray_cast_inner <- function(x, to) {
+  # same as vctrs:::shape_broadcast() in this case
+  to <- rray_reshape(to, shape_dim(x))
+
+  res <- vec_cast(vec_data(x), to)
+
+  vec_restore(res, x)
+}
+
+# Cast inputs to the same _inner_ types
+# <vctrs_rray<integer>[,2][2]> -> <vctrs_rray<double>[,2][2]>
+# <vctrs_rray<double>[,1][2]>  -> <vctrs_rray<double>[,1][2]>
+# notice that shapes haven't been cast to a common shape
+rray_cast_inner_common <- function(..., .to = NULL) {
+  args <- list2(...)
+  inner_type <- rray_type_inner_common(!!!args, .ptype = .to)
+  map(args, rray_cast_inner, to = inner_type)
+}
+
+shape_dim <- function(x) {
+  dim <- vec_dim(x)
+  dim[1] <- 0L
+  dim
+}

--- a/R/inner.R
+++ b/R/inner.R
@@ -28,11 +28,19 @@ rray_type_inner_common <- function(..., .ptype = NULL) {
   vctrs::vec_type_finalise(ptype)
 }
 
+# - No change in dim/shape
+# - Only changing the inner type of the data
+# - Names are kept
 rray_cast_inner <- function(x, to) {
+
+  to <- rray_type_inner(to)
+
   # same as vctrs:::shape_broadcast() in this case
   to <- rray_reshape(to, shape_dim(x))
 
   res <- vec_cast(vec_data(x), to)
+
+  res <- set_full_dim_names(res, dim_names(x))
 
   vec_restore(res, x)
 }

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -81,4 +81,9 @@ test_that("using base coercing functions", {
   expect_is(x_int, "matrix")
   expect_equal(dim(x_int), c(1, 2))
   expect_equal(storage.mode(x_int), "integer")
+
+  x_lgl <- as.logical(x)
+  expect_is(x_lgl, "matrix")
+  expect_equal(dim(x_lgl), c(1, 2))
+  expect_equal(storage.mode(x_lgl), "logical")
 })


### PR DESCRIPTION
Closes #51 

- We now have formal infrastructure for _only_ casting the "inner" type of an object. This is helpful because we often need to convert from a double matrix to integer matrix without changing shape.
- `vec_type2()` and `vec_cast()` are simplified by using these inner type functions.
- `vec_cast()` now keeps the names of `x` where possible, using dimension name handling rules (i.e. they are lost if that dimension is broadcast)
- `vec_type2()` still does not keep names
- Base coercion functions `as.double.vctrs_rray()` were simplified by the use of inner type functions