### PR TITLE
Supersubset relax

### DIFF
--- a/R/subset.R
+++ b/R/subset.R
@@ -210,7 +210,8 @@ front_pad <- function(i, axis) {
 #'
 #' `rray_yank()` is the counterpart to [rray_extract()]. It extracts elements
 #' from an array _by position_. It _always_ drops dimensions
-#' (unlike [rray_subset()]), and a 1D vector is always returned.
+#' (unlike [rray_subset()]), and a 1D vector is always returned. It powers
+#' the `[[` method for rrays.
 #'
 #' @param x A vector, matrix, array or rray.
 #'
@@ -221,6 +222,8 @@ front_pad <- function(i, axis) {
 #'
 #' @param value A 1D value to be assigned to the location yanked by `i`. It will
 #' be cast to the type and length of `x` after being yanked by `i`.
+#'
+#' @param ... Not used. An error is thrown if extra arguments are supplied here.
 #'
 #' @details
 #'
@@ -233,8 +236,14 @@ front_pad <- function(i, axis) {
 #' `x[i]` since `[` for rray objects is much stricter. Separating this special
 #' behavior into a different function is less surprising.
 #'
-#' @examples
+#' Additionally, base R has `x[[i]]` which restricts `i` to be length 1.
+#' For rray objects, `[[` acts more like `x[i]`, always dropping to 1D, but
+#' allowing for the selection of multiple positions.
 #'
+#' You _cannot_ do `x[[i, j, ...]]` with rrays. For that behavior,
+#' see [rray_extract()].
+#'
+#' @examples
 #' x <- rray(10:17, c(2, 2, 2))
 #'
 #' # Resulting dimension is always 1D
@@ -255,10 +264,38 @@ front_pad <- function(i, axis) {
 #' # And you can set elements in these locations
 #' rray_yank(x, lgl) <- NA
 #'
+#' # `[[` for rray objects is powered by
+#' # rray_yank().
+#' # This can be very useful for
+#' # performing assignment
+#' # by position.
+#' x[[c(1, 3)]] <- NA
+#'
+#' # Logical arrays with the same shape as `x`
+#' # can be assigned to. This is a useful way
+#' # to get rid of NA values.
+#' idx <- array(is.na(as.vector(x)), c(2, 2, 2))
+#'
+#' x[[idx]] <- 0
+#'
 #' @family rray subsetters
 #' @export
 rray_yank <- function(x, i) {
   rray_yank_impl(x, maybe_missing(i))
+}
+
+#' @rdname rray_yank
+#' @export
+`[[.vctrs_rray` <- function(x, i, ...) {
+
+  validate_empty_yank_dots(...)
+
+  # TODO - is this inconsistent behavior ok?
+  # `rray_yank()` maintains dim names if `x` is 1D.
+  # `[[` should never keep them
+  dim_names(x) <- NULL
+
+  rray_yank_impl(x, i)
 }
 
 rray_yank_impl <- function(x, i) {
@@ -277,6 +314,13 @@ rray_yank_impl <- function(x, i) {
 #' @export
 `rray_yank<-` <- function(x, i, value) {
   rray_yank_assign_impl(x, i = maybe_missing(i), value = value)
+}
+
+#' @rdname rray_yank
+#' @export
+`[[<-.vctrs_rray` <- function(x, i, ..., value) {
+  validate_empty_yank_assign_dots(...)
+  rray_yank_assign_impl(x, i = i, value = value)
 }
 
 rray_yank_assign_impl <- function(x, i, value) {
@@ -309,9 +353,6 @@ rray_yank_assign_impl <- function(x, i, value) {
 #' Before assignment, `value` is cast to the type and dimension of `x` after
 #' extracting elements with `...`.
 #'
-#' @param exact Ignored, but preserved for better error messages with code
-#' that might have used arrays before.
-#'
 #' @details
 #'
 #' Like `[[`, `rray_extract()` will _never_ keep dimension names.
@@ -321,15 +362,7 @@ rray_yank_assign_impl <- function(x, i, value) {
 #' `rray_extract()` is similar to the traditional behavior of
 #' `x[[i, j, ...]]`, but allows each subscript to have length >1.
 #'
-#' The `[[` method for rrays is a stricter combination of [rray_yank()] and
-#' `rray_extract()`.
-#' - It utilizes `rray_yank()` for `x[[i]]` and
-#' `rray_extract()` for `x[[i, j, ...]]`.
-#' - It never keeps dimension names.
-#' - Each subscript can only have length 1.
-#'
 #' @examples
-#'
 #' x <- rray(1:16, c(2, 4, 2), dim_names = list(c("r1", "r2"), NULL, NULL))
 #'
 #' # Extract the first row and flatten it
@@ -342,34 +375,9 @@ rray_yank_assign_impl <- function(x, i, value) {
 #' rray_extract(x, 1, 1:2) <- NA
 #' x
 #'
-#' # `[[` for rray objects is powered by
-#' # rray_extract() and rray_yank().
-#' # These are equivalent ways to get at
-#' # a flattened version of `x[2, 2, 1]`
-#' x[[4]]
-#' x[[2, 2, 1]]
-#'
-#' # Both ways can be used in assignment
-#' x[[4]] <- 100
-#' x[[2, 2, 1]] <- 99
-#'
 #' @export
 rray_extract <- function(x, ...) {
   rray_extract_impl(x, ...)
-}
-
-#' @rdname rray_extract
-#' @export
-`[[.vctrs_rray` <- function(x, i, ...) {
-
-  validate_empty_yank_dots(...)
-
-  # TODO - is this inconsistent behavior ok?
-  # `rray_yank()` maintains dim names if `x` is 1D.
-  # `[[` should never keep them
-  dim_names(x) <- NULL
-
-  rray_yank_impl(x, i)
 }
 
 rray_extract_impl <- function(x, ...) {
@@ -388,13 +396,6 @@ rray_extract_impl <- function(x, ...) {
 #' @export
 `rray_extract<-` <- function(x, ..., value) {
   rray_extract_assign_impl(x, ..., value = value)
-}
-
-#' @rdname rray_extract
-#' @export
-`[[<-.vctrs_rray` <- function(x, i, ..., value) {
-  validate_empty_yank_assign_dots(...)
-  rray_yank_assign_impl(x, i = i, value = value)
 }
 
 rray_extract_assign_impl <- function(x, ..., value) {

--- a/R/subset.R
+++ b/R/subset.R
@@ -375,6 +375,7 @@ rray_yank_assign_impl <- function(x, i, value) {
 #' rray_extract(x, 1, 1:2) <- NA
 #' x
 #'
+#' @family rray subsetters
 #' @export
 rray_extract <- function(x, ...) {
   rray_extract_impl(x, ...)

--- a/man/rray_extract.Rd
+++ b/man/rray_extract.Rd
@@ -2,18 +2,12 @@
 % Please edit documentation in R/subset.R
 \name{rray_extract}
 \alias{rray_extract}
-\alias{[[.vctrs_rray}
 \alias{rray_extract<-}
-\alias{[[<-.vctrs_rray}
 \title{Get or set elements of an array by index}
 \usage{
 rray_extract(x, ...)
 
-\method{[[}{vctrs_rray}(x, ..., exact = TRUE)
-
 rray_extract(x, ...) <- value
-
-\method{[[}{vctrs_rray}(x, ...) <- value
 }
 \arguments{
 \item{x}{An rray.}
@@ -27,9 +21,6 @@ subsetting over.
 dimension.
 \item \code{NULL} is treated as \code{0}.
 }}
-
-\item{exact}{Ignored, but preserved for better error messages with code
-that might have used arrays before.}
 
 \item{value}{The value to assign to the location specified by \code{...}.
 Before assignment, \code{value} is cast to the type and dimension of \code{x} after
@@ -47,18 +38,8 @@ Like \code{[[}, \code{rray_extract()} will \emph{never} keep dimension names.
 
 \code{rray_extract()} is similar to the traditional behavior of
 \code{x[[i, j, ...]]}, but allows each subscript to have length >1.
-
-The \code{[[} method for rrays is a stricter combination of \code{\link[=rray_yank]{rray_yank()}} and
-\code{rray_extract()}.
-\itemize{
-\item It utilizes \code{rray_yank()} for \code{x[[i]]} and
-\code{rray_extract()} for \code{x[[i, j, ...]]}.
-\item It never keeps dimension names.
-\item Each subscript can only have length 1.
-}
 }
 \examples{
-
 x <- rray(1:16, c(2, 4, 2), dim_names = list(c("r1", "r2"), NULL, NULL))
 
 # Extract the first row and flatten it
@@ -70,16 +51,5 @@ rray_extract(x, 1, 1:2)
 # You can assign directly to these elements
 rray_extract(x, 1, 1:2) <- NA
 x
-
-# `[[` for rray objects is powered by
-# rray_extract() and rray_yank().
-# These are equivalent ways to get at
-# a flattened version of `x[2, 2, 1]`
-x[[4]]
-x[[2, 2, 1]]
-
-# Both ways can be used in assignment
-x[[4]] <- 100
-x[[2, 2, 1]] <- 99
 
 }

--- a/man/rray_extract.Rd
+++ b/man/rray_extract.Rd
@@ -53,3 +53,8 @@ rray_extract(x, 1, 1:2) <- NA
 x
 
 }
+\seealso{
+Other rray subsetters: \code{\link{rray_slice}},
+  \code{\link{rray_subset}}, \code{\link{rray_yank}}
+}
+\concept{rray subsetters}

--- a/man/rray_slice.Rd
+++ b/man/rray_slice.Rd
@@ -47,7 +47,7 @@ rray_slice(x, 1, 3) <- matrix(c(99, 100), nrow = 1)
 
 }
 \seealso{
-Other rray subsetters: \code{\link{rray_subset}},
-  \code{\link{rray_yank}}
+Other rray subsetters: \code{\link{rray_extract}},
+  \code{\link{rray_subset}}, \code{\link{rray_yank}}
 }
 \concept{rray subsetters}

--- a/man/rray_subset.Rd
+++ b/man/rray_subset.Rd
@@ -109,7 +109,7 @@ x_arr
 
 }
 \seealso{
-Other rray subsetters: \code{\link{rray_slice}},
-  \code{\link{rray_yank}}
+Other rray subsetters: \code{\link{rray_extract}},
+  \code{\link{rray_slice}}, \code{\link{rray_yank}}
 }
 \concept{rray subsetters}

--- a/man/rray_yank.Rd
+++ b/man/rray_yank.Rd
@@ -2,12 +2,18 @@
 % Please edit documentation in R/subset.R
 \name{rray_yank}
 \alias{rray_yank}
+\alias{[[.vctrs_rray}
 \alias{rray_yank<-}
+\alias{[[<-.vctrs_rray}
 \title{Get or set elements of an array by position}
 \usage{
 rray_yank(x, i)
 
+\method{[[}{vctrs_rray}(x, i, ...)
+
 rray_yank(x, i) <- value
+
+\method{[[}{vctrs_rray}(x, i, ...) <- value
 }
 \arguments{
 \item{x}{A vector, matrix, array or rray.}
@@ -19,13 +25,16 @@ rray_yank(x, i) <- value
 \item A logical with the same dimension as \code{x}.
 }}
 
+\item{...}{Not used. An error is thrown if extra arguments are supplied here.}
+
 \item{value}{A 1D value to be assigned to the location yanked by \code{i}. It will
 be cast to the type and length of \code{x} after being yanked by \code{i}.}
 }
 \description{
 \code{rray_yank()} is the counterpart to \code{\link[=rray_extract]{rray_extract()}}. It extracts elements
 from an array \emph{by position}. It \emph{always} drops dimensions
-(unlike \code{\link[=rray_subset]{rray_subset()}}), and a 1D vector is always returned.
+(unlike \code{\link[=rray_subset]{rray_subset()}}), and a 1D vector is always returned. It powers
+the \code{[[} method for rrays.
 }
 \details{
 Dimension names are \emph{only} kept in the special case of calling \code{rray_yank()}
@@ -36,9 +45,15 @@ on a 1D object. Otherwise, the method of keeping them is not well defined.
 \code{rray_yank()} is meant as a replacement for the traditional behavior of
 \code{x[i]} since \code{[} for rray objects is much stricter. Separating this special
 behavior into a different function is less surprising.
+
+Additionally, base R has \code{x[[i]]} which restricts \code{i} to be length 1.
+For rray objects, \code{[[} acts more like \code{x[i]}, always dropping to 1D, but
+allowing for the selection of multiple positions.
+
+You \emph{cannot} do \code{x[[i, j, ...]]} with rrays. For that behavior,
+see \code{\link[=rray_extract]{rray_extract()}}.
 }
 \examples{
-
 x <- rray(10:17, c(2, 2, 2))
 
 # Resulting dimension is always 1D
@@ -58,6 +73,20 @@ rray_yank(x, lgl)
 
 # And you can set elements in these locations
 rray_yank(x, lgl) <- NA
+
+# `[[` for rray objects is powered by
+# rray_yank().
+# This can be very useful for
+# performing assignment
+# by position.
+x[[c(1, 3)]] <- NA
+
+# Logical arrays with the same shape as `x`
+# can be assigned to. This is a useful way
+# to get rid of NA values.
+idx <- array(is.na(as.vector(x)), c(2, 2, 2))
+
+x[[idx]] <- 0
 
 }
 \seealso{

--- a/man/rray_yank.Rd
+++ b/man/rray_yank.Rd
@@ -90,7 +90,7 @@ x[[idx]] <- 0
 
 }
 \seealso{
-Other rray subsetters: \code{\link{rray_slice}},
-  \code{\link{rray_subset}}
+Other rray subsetters: \code{\link{rray_extract}},
+  \code{\link{rray_slice}}, \code{\link{rray_subset}}
 }
 \concept{rray subsetters}

--- a/tests/testthat/test-subset.R
+++ b/tests/testthat/test-subset.R
@@ -594,32 +594,23 @@ test_that("names are never kept with [[", {
   expect_equal(dim_names(x[[1]]), new_empty_dim_names(1))
 })
 
-test_that("cannot use >1 length subscripts with `[[`", {
-  x <- rray(1:2)
-  expect_error(x[[c(1, 2)]], "1, not 2")
+test_that("cannot use >1 indexer", {
+  x <- rray(1:8, c(2, 4))
+  expect_error(x[[c(1, 2), c(1, 2)]], "but 2 indexers")
 })
 
 test_that("can use positional [[", {
   x <- rray(1:8, c(2, 2, 2))
   expect_equal(x[[3]], rray(3L))
-})
-
-test_that("can use index extraction [[", {
-  x <- rray(1:8, c(2, 2, 2))
-  expect_equal(x[[1, 2, 1]], rray(3L))
-})
-
-test_that("partial indexes are not allowed", {
-  x <- rray(1:8, c(2, 2, 2))
-  expect_error(x[[1, 2]], "3 must not be missing")
+  expect_equal(x[[c(3, 4)]], rray(c(3L, 4L)))
 })
 
 test_that("trailing dots are not ignored", {
   x <- rray(1:8, c(2, 2, 2))
-  expect_error(x[[1,]], "2, 3 must not be missing")
+  expect_error(x[[1,]], "but 2 indexers")
 
   x <- rray(1:4, c(2, 2))
-  expect_error(x[[1,]], "2 must not be missing")
+  expect_error(x[[1,]], "but 2 indexers")
 })
 
 # ------------------------------------------------------------------------------
@@ -632,29 +623,41 @@ test_that("can use a [[ position assign", {
   expect_equal(as.vector(x), c(NA, 2:8))
 })
 
-test_that("can use a [[ index assign", {
+test_that("can assign to non-contiguous positions", {
   x <- rray(1:8, dim = c(2, 2, 2))
-  x[[1, 1, 1]] <- NA
+  x[[c(1, 3)]] <- NA
   expect_is(x, "vctrs_rray")
-  expect_equal(as.vector(x), c(NA, 2:8))
+  expect_equal(as.vector(x), c(NA, 2, NA, 4:8))
 })
 
-test_that("cannot use >1 length subscripts with `[[<-`", {
-  x <- rray(1:2)
-  expect_error(x[[c(1, 2)]] <- c(1, 2), "1, not 2")
+test_that("can assign with a logical matrix", {
+  x <- rray(1:8, dim = c(2, 2, 2))
+  idx <- rray(c(FALSE, TRUE, rep(FALSE, 6)), c(2, 2, 2))
+  x[[idx]] <- NA
+  expect_is(x, "vctrs_rray")
+  expect_equal(as.vector(x), c(1, NA, 3:8))
 })
 
-test_that("partial indexes are not allowed in `[[<-", {
-  x <- rray(1:8, c(2, 2, 2))
-  expect_error(x[[1, 2]] <- 1, "3 must not be missing")
+test_that("can assign with a logical vector", {
+  x <- rray(1:8, dim = c(2, 2, 2))
+  idx <- c(FALSE, TRUE, rep(FALSE, 6))
+  x[[idx]] <- NA
+  expect_is(x, "vctrs_rray")
+  expect_equal(as.vector(x), c(1, NA, 3:8))
+})
+
+test_that("cannot use a [[ index assign", {
+  x <- rray(1:8, dim = c(2, 2, 2))
+  expect_error(x[[1, 1, 1]] <- NA, "but 3 indexers")
+  expect_error(x[[1, 1, 1]] <- NA, "value")
 })
 
 test_that("trailing dots are not ignored in `[[<-`", {
   x <- rray(1:8, c(2, 2, 2))
-  expect_error(x[[1,]] <- 1, "2, 3 must not be missing")
+  expect_error(x[[1,]] <- 1, "2 indexers")
 
   x <- rray(1:4, c(2, 2))
-  expect_error(x[[1,]] <- 1, "2 must not be missing")
+  expect_error(x[[1,]] <- 1, "2 indexers")
 })
 
 test_that("assigning NULL in `[[<-` is an error", {


### PR DESCRIPTION
Closes #77 

- `rray_yank()` now fully powers `[[`

This has two repercussions:

- `x[[c(1, 2)]]` and `x[[is.na(x)]]` will both be allowed, and will function as the replacements for base R's behavior of `x[c(1, 2)]`.
- We no longer allow behavior like `x[[1, 1]]`. At first I thought this would be possible with `rray_extract()`, but this case would be ambiguous: `x[[1]]`. Do we want the first row, or the first position? Because of this, `[[` _only_ subsets with position, which is the more common case. 
- To subset like `x[[1, 1]]` use `rray_extract()` which also allows for `x[[1:2, 1:2]]` (multiple dimensions per indices)