### PR TITLE
Update `rray_reshape()`

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -33,6 +33,10 @@ rray__increase_dims <- function(dim, dims) {
     .Call(`_rray_rray__increase_dims`, dim, dims)
 }
 
+rray__reshape <- function(x, dim) {
+    .Call(`_rray_rray__reshape`, x, dim)
+}
+
 rray_op_binary_cpp <- function(op, x, y) {
     .Call(`_rray_rray_op_binary_cpp`, op, x, y)
 }
@@ -71,5 +75,13 @@ rray__min_pos <- function(x, axis) {
 
 rray_reducer_cpp <- function(op, x, axes) {
     .Call(`_rray_rray_reducer_cpp`, op, x, axes)
+}
+
+rray__validate_dim <- function(dim) {
+    invisible(.Call(`_rray_rray__validate_dim`, dim))
+}
+
+rray__validate_reshape <- function(x, dim) {
+    invisible(.Call(`_rray_rray__validate_reshape`, x, dim))
 }
 

--- a/R/reshape.R
+++ b/R/reshape.R
@@ -9,13 +9,7 @@ rray_reshape <- function(x, dim) {
 
   dim <- vec_cast(dim, integer())
 
-  if (identical(rray_dim(x), dim)) {
-    return(x)
-  }
-
-  validate_reshape(x, dim)
-
-  res <- rray_reshape_impl(x, dim)
+  res <- rray__reshape(x, dim)
 
   # Actually going down in dimensions here,
   # but restore_dim_names() can handle that
@@ -23,37 +17,4 @@ rray_reshape <- function(x, dim) {
   res <- set_full_dim_names(res, new_dim_names)
 
   vec_restore(res, x)
-}
-
-rray_reshape_impl <- function(x, dim) {
-  rray_op_unary_one_cpp("reshape", x, dim)
-}
-
-validate_reshape <- function(x, to) {
-
-  if (is.null(x)) {
-    return(invisible(x))
-  }
-
-  validate_dim(to)
-
-  from <- rray_dim(x)
-
-  size_from <- prod(from)
-  size_to   <- prod(to)
-
-  if (size_from != size_to) {
-    glubort(
-      "The size you are reshaping from ({size_from}) ",
-      "must be equal to the size you are reshaping to ({size_to})."
-    )
-  }
-
-  invisible(x)
-}
-
-validate_dim <- function(dim) {
-  if (!all(dim >= 0L)) {
-    abort("`dim` must be a positive vector.")
-  }
 }

--- a/inst/include/api.h
+++ b/inst/include/api.h
@@ -14,6 +14,18 @@ Rcpp::IntegerVector rray__increase_dims(const Rcpp::IntegerVector& dim,
                                         const int& dims);
 
 // -----------------------------------------------------------------------------
+// Miscellaneous
+
+int rray__prod(Rcpp::IntegerVector x);
+
+// -----------------------------------------------------------------------------
+// Validation
+
+void rray__validate_dim(Rcpp::IntegerVector dim);
+
+void rray__validate_reshape(Rcpp::RObject x, Rcpp::IntegerVector dim);
+
+// -----------------------------------------------------------------------------
 // Re-exposed R API
 
 bool r_identical(SEXP x, SEXP y);

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -98,6 +98,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// rray__reshape
+Rcpp::RObject rray__reshape(Rcpp::RObject x, Rcpp::IntegerVector dim);
+RcppExport SEXP _rray_rray__reshape(SEXP xSEXP, SEXP dimSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::RObject >::type x(xSEXP);
+    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type dim(dimSEXP);
+    rcpp_result_gen = Rcpp::wrap(rray__reshape(x, dim));
+    return rcpp_result_gen;
+END_RCPP
+}
 // rray_op_binary_cpp
 SEXP rray_op_binary_cpp(const std::string& op, SEXP x, SEXP y);
 RcppExport SEXP _rray_rray_op_binary_cpp(SEXP opSEXP, SEXP xSEXP, SEXP ySEXP) {
@@ -228,6 +240,27 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// rray__validate_dim
+void rray__validate_dim(Rcpp::IntegerVector dim);
+RcppExport SEXP _rray_rray__validate_dim(SEXP dimSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type dim(dimSEXP);
+    rray__validate_dim(dim);
+    return R_NilValue;
+END_RCPP
+}
+// rray__validate_reshape
+void rray__validate_reshape(Rcpp::RObject x, Rcpp::IntegerVector dim);
+RcppExport SEXP _rray_rray__validate_reshape(SEXP xSEXP, SEXP dimSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::RObject >::type x(xSEXP);
+    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type dim(dimSEXP);
+    rray__validate_reshape(x, dim);
+    return R_NilValue;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_rray_rray__broadcast", (DL_FUNC) &_rray_rray__broadcast, 2},
@@ -238,6 +271,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rray_rray__dim", (DL_FUNC) &_rray_rray__dim, 1},
     {"_rray_rray__dims", (DL_FUNC) &_rray_rray__dims, 1},
     {"_rray_rray__increase_dims", (DL_FUNC) &_rray_rray__increase_dims, 2},
+    {"_rray_rray__reshape", (DL_FUNC) &_rray_rray__reshape, 2},
     {"_rray_rray_op_binary_cpp", (DL_FUNC) &_rray_rray_op_binary_cpp, 3},
     {"_rray_rray_op_trinary_cpp", (DL_FUNC) &_rray_rray_op_trinary_cpp, 4},
     {"_rray_rray_op_unary_one_cpp", (DL_FUNC) &_rray_rray_op_unary_one_cpp, 3},
@@ -248,6 +282,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rray_rray__max_pos", (DL_FUNC) &_rray_rray__max_pos, 2},
     {"_rray_rray__min_pos", (DL_FUNC) &_rray_rray__min_pos, 2},
     {"_rray_rray_reducer_cpp", (DL_FUNC) &_rray_rray_reducer_cpp, 3},
+    {"_rray_rray__validate_dim", (DL_FUNC) &_rray_rray__validate_dim, 1},
+    {"_rray_rray__validate_reshape", (DL_FUNC) &_rray_rray__validate_reshape, 2},
     {NULL, NULL, 0}
 };
 

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -1,0 +1,34 @@
+#include <rray.h>
+#include <dispatch.h>
+
+// -----------------------------------------------------------------------------
+
+// Note: Don't treat `x` as a `const rarray&`. We have the option
+// to early exit and return x without modification. Using a const
+// reference would force the copy on the way out.
+
+template <typename T>
+xt::rarray<T> rray__reshape_impl(xt::rarray<T> x, Rcpp::IntegerVector dim) {
+
+  using vec_size_t = typename std::vector<std::size_t>;
+
+  // Early exit, no reshape needed (no copy made)
+  if (r_identical(rray__dim(SEXP(x)), dim)) {
+    return x;
+  }
+
+  rray__validate_reshape(SEXP(x), dim);
+
+  const vec_size_t& xt_dim = Rcpp::as<vec_size_t>(dim);
+
+  xt::rarray<T> out = xt::reshape_view(x, xt_dim, xt::layout_type::column_major);
+
+  return out;
+}
+
+// [[Rcpp::export]]
+Rcpp::RObject rray__reshape(Rcpp::RObject x, Rcpp::IntegerVector dim) {
+  DISPATCH_UNARY_ONE(rray__reshape_impl, x, dim);
+}
+
+// -----------------------------------------------------------------------------

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -1,0 +1,11 @@
+#include <api.h>
+
+int rray__prod(Rcpp::IntegerVector x) {
+  int prod = 1;
+
+  for (int i = 0; i < x.size(); ++i) {
+    prod *= x[i];
+  }
+
+  return prod;
+}

--- a/src/op-unary-one.cpp
+++ b/src/op-unary-one.cpp
@@ -61,22 +61,6 @@ SEXP rray_cumprod_cpp(const xt::rarray<T>& x, SEXP arg) {
 }
 
 // -----------------------------------------------------------------------------
-// Generators
-
-template <typename T>
-SEXP rray_reshape_cpp(const xt::rarray<T>& x, SEXP arg) {
-
-  std::vector<std::size_t> dim = Rcpp::as<std::vector<std::size_t>>(arg);
-
-  // needs a copy, otherwise modifying x
-  xt::rarray<T> res(x);
-
-  res.reshape(dim);
-
-  return(res);
-}
-
-// -----------------------------------------------------------------------------
 // Manipulation
 
 template <typename T>
@@ -149,13 +133,6 @@ SEXP rray_op_unary_one_cpp_impl(std::string op, const xt::rarray<T1>& x, SEXP ar
 
   case str2int("cumprod"): {
     return rray_cumprod_cpp(x, arg);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Generators
-
-  case str2int("reshape"): {
-    return rray_reshape_cpp(x, arg);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1,0 +1,27 @@
+#include <api.h>
+
+// [[Rcpp::export]]
+void rray__validate_dim(Rcpp::IntegerVector dim) {
+  bool not_ok = Rcpp::is_true(Rcpp::any(dim < 0));
+
+  if (not_ok) {
+    Rcpp::stop("`dim` must be a positive integer vector.");
+  }
+}
+
+// [[Rcpp::export]]
+void rray__validate_reshape(Rcpp::RObject x, Rcpp::IntegerVector dim) {
+
+  rray__validate_dim(dim);
+
+  int x_size = rray__prod(rray__dim(x));
+  int new_size = rray__prod(dim);
+
+  if (x_size != new_size) {
+    Rcpp::stop(
+      "The size you are reshaping from (%i) must be equal to the size you are reshaping to (%i).",
+      x_size, new_size
+    );
+  }
+
+}

--- a/tests/testthat/test-reshape.R
+++ b/tests/testthat/test-reshape.R
@@ -92,3 +92,8 @@ test_that("can reshape 0 column input", {
 test_that("can reshape with `NULL` input", {
   expect_equal(rray_reshape(NULL, c(1, 2)), NULL)
 })
+
+test_that("errors are thrown when reshaping to the wrong size", {
+  expect_error(rray_reshape(numeric(), 1), "The size you are reshaping from")
+  expect_error(rray_reshape(1, c(1, 2)), "The size you are reshaping from")
+})


### PR DESCRIPTION
This PR updates `rray_reshape()` and moves more of the validation and computation to the C++ side.

It also ends up creating 3 new helpers in the api, `rray__prod()`, `rray__validate_dim()`, and `rray__validate_reshape()`