### PR TITLE
Improve `rray_split()`

### DIFF
--- a/R/reducers.R
+++ b/R/reducers.R
@@ -172,10 +172,6 @@ validate_axes <- function(axes, x, n = NULL, nm = "axes", dims = NULL) {
     return(invisible(NULL))
   }
 
-  if (length(axes) == 0L) {
-    glubort("`axes` must have size >=1, not 0.")
-  }
-
   if (is.null(x)) {
     return(invisible(NULL))
   }

--- a/R/split.R
+++ b/R/split.R
@@ -1,10 +1,12 @@
-#' Split an array along an axis
+#' Split an array along axes
 #'
-#' `rray_split()` splits `x` into `n` equal pieces, splitting along an `axis`.
+#' `rray_split()` splits `x` into equal pieces, splitting along the `axes`.
 #'
 #' @param x A vector, matrix, array, or rray.
 #'
-#' @param axes An integer vector. The axes to split on.
+#' @param axes An integer vector. The axes to split on. The default splits
+#' along all axes, and does so in reverse order, which produces the most
+#' intuitive result.
 #'
 #' @param n An integer vector, or `NULL`. By default, this is computed as the
 #' dimension size of each axis specified in `axes`. If not `NULL`, it should
@@ -30,12 +32,20 @@
 #' # (i.e. 2 then 1)
 #' rray_split(x, c(2, 1))
 #'
+#' # The above split is what the default behavior does
+#' rray_split(x)
+#'
 #' # Split along rows in chunks of 2
 #' rray_split(x, 1, 2)
 #'
 #' # Split along columns and then
 #' # rows in chunks of 2
 #' rray_split(x, c(2, 1), c(2, 2))
+#'
+#' # You can technically split with a size 0 `axes`
+#' # argument, which essentially requests no axes
+#' # to be split and is the same as `list(x)`
+#' rray_split(x, axes = integer(0))
 #'
 #'
 #' # 4 dimensional example

--- a/R/split.R
+++ b/R/split.R
@@ -64,10 +64,14 @@
 #' rray_split(x_4d, c(4, 3))
 #'
 #' @export
-rray_split <- function(x, axes, n = NULL) {
+rray_split <- function(x, axes = NULL, n = NULL) {
 
   axes <- vec_cast(axes, integer())
   validate_axes(axes, x)
+
+  if (is_null(axes)) {
+    axes <- rev(seq_len(rray_dims(x)))
+  }
 
   # Default to size of the axes
   if (is_null(n)) {

--- a/man/rray_split.Rd
+++ b/man/rray_split.Rd
@@ -2,14 +2,16 @@
 % Please edit documentation in R/split.R
 \name{rray_split}
 \alias{rray_split}
-\title{Split an array along an axis}
+\title{Split an array along axes}
 \usage{
-rray_split(x, axes, n = NULL)
+rray_split(x, axes = NULL, n = NULL)
 }
 \arguments{
 \item{x}{A vector, matrix, array, or rray.}
 
-\item{axes}{An integer vector. The axes to split on.}
+\item{axes}{An integer vector. The axes to split on. The default splits
+along all axes, and does so in reverse order, which produces the most
+intuitive result.}
 
 \item{n}{An integer vector, or \code{NULL}. By default, this is computed as the
 dimension size of each axis specified in \code{axes}. If not \code{NULL}, it should
@@ -19,7 +21,7 @@ be the same length as \code{axes}.}
 A list of equal pieces of type \code{x}.
 }
 \description{
-\code{rray_split()} splits \code{x} into \code{n} equal pieces, splitting along an \code{axis}.
+\code{rray_split()} splits \code{x} into equal pieces, splitting along the \code{axes}.
 }
 \examples{
 
@@ -37,12 +39,20 @@ rray_split(x, 2)
 # (i.e. 2 then 1)
 rray_split(x, c(2, 1))
 
+# The above split is what the default behavior does
+rray_split(x)
+
 # Split along rows in chunks of 2
 rray_split(x, 1, 2)
 
 # Split along columns and then
 # rows in chunks of 2
 rray_split(x, c(2, 1), c(2, 2))
+
+# You can technically split with a size 0 `axes`
+# argument, which essentially requests no axes
+# to be split and is the same as `list(x)`
+rray_split(x, axes = integer(0))
 
 
 # 4 dimensional example

--- a/tests/testthat/test-split.R
+++ b/tests/testthat/test-split.R
@@ -107,3 +107,18 @@ test_that("`n` must divide equally", {
   x <- array(1:8, dim = c(2, 4), dimnames = list(NULL))
   expect_error(rray_split(x, 1, n = 3), "does not result in equal division")
 })
+
+test_that("can split with NULL axes", {
+  x <- array(1:8, dim = c(2, 4), dimnames = list(NULL))
+  expect_equal(rray_split(x), rray_split(x, axes = c(2, 1)))
+  expect_equal(rray_split(x, n = c(2, 2)), rray_split(x, axes = c(2, 1), n = c(2, 2)))
+})
+
+test_that("can split with integer(0) axis", {
+  x <- array(1:8, dim = c(2, 4), dimnames = list(NULL))
+  expect_equal(rray_split(x, axes = integer()), list(x))
+  expect_equal(rray_split(x, axes = integer(), n = integer()), list(x))
+})
+
+
+


### PR DESCRIPTION
There was a restriction in `validate_axes()` that prevented `integer()` from being a valid axis argument. This is perfectly valid, and means that you just don't split or reduce over any axes.

This flows through to `rray_split()`, so that `integer()` now has a well defined result. A few tests were added for that.

Also, `rray_split()` now accepts `NULL` for axes, which defaults to all of the axes, but in reverse order.