### PR TITLE
Fix `rray_duplicate_*()` functions

### DIFF
--- a/R/duplicate.R
+++ b/R/duplicate.R
@@ -2,28 +2,20 @@
 #'
 #' @description
 #'
-#' * `rray_duplicate_any()`: detects the presence of duplicated values,
-#' similar to [anyDuplicated()] with the `MARGIN` argument.
+#' * `rray_duplicate_any()`: returns a logical with the same shape and type
+#' as `x` except over the `axes`, which will be reduced to length 1. This
+#' function detects the presence of any duplicated values along the `axes`.
 #'
-#' * `rray_duplicate_detect()`: returns a logical vector describing if each
-#' element of the vector is duplicated elsewhere. It is similar to
-#' [duplicated()] with the `MARGIN` argument, but it reports all duplicated
-#' values, not just the second and subsequent repetitions.
+#' * `rray_duplicate_detect()`: returns a logical with the same shape and
+#' type as `x` describing if that element of `x` is duplicated elsewhere.
 #'
-#' * `rray_duplicate_id()`: returns an integer vector giving the location of the
-#' first occurence of the value.
+#' * `rray_duplicate_id()`: returns an integer with the same shape and
+#' type as `x` giving the location of the first occurence of the value.
 #'
 #' @param x A vector, matrix, array, or rray.
 #'
-#' @param axis A single integer. The axis to look for duplicate values over.
-#'
-#' @return
-#'
-#' * `rray_duplicate_any()`: a logical vector of length 1.
-#'
-#' * `rray_duplicate_detect()`: a logical vector the same length as `x`.
-#'
-#' * `rray_duplicate_id()`: an integer vector the same length as `x`.
+#' @param axes An integer vector. The default of `NULL` looks for duplicates
+#' over all axes.
 #'
 #' @seealso
 #'
@@ -48,31 +40,32 @@
 #' # where the columns are not unique
 #' y <- rray_expand_dims(x, 1)
 #'
-#' # All of the rows are unique...
+#' # Along the rows, all the values are unique...
 #' rray_duplicate_any(y, 1L)
 #'
-#' # ...but the columns are not
+#' # ...but along the columns there are duplicates
 #' rray_duplicate_any(y, 2L)
 #'
-#' # rray_duplicate_detect() returns
-#' # `TRUE` if a duplicate is detected
-#' # anywhere in the array (both
-#' # columns are registered as
-#' # duplicates)
-#' rray_duplicate_detect(y, 2)
+#' # ---------------------------------------------------------------------------
 #'
-#' # duplicated() only returns `TRUE`
-#' # for the second and all subsequent
-#' # duplicates
-#' duplicated(as_array(y), MARGIN = 2L)
+#' z <- rray(c(1, 1, 2, 3, 1, 4, 5, 6), c(2, 2, 2))
 #'
-#' # Find the location of the
-#' # first unique values
-#' rray_duplicate_id(y, 2L)
+#' # rray_duplicate_detect() looks for any
+#' # duplicates along the axes of interest
+#' # and returns `TRUE` wherever a duplicate is found
+#' # (including the first location)
+#' rray_duplicate_detect(z, 1)
 #'
-#' # Both of the 3rd dimension elements
-#' # are unique
-#' rray_duplicate_id(y, 3L)
+#' # Positions 1 and 5 are the same!
+#' rray_duplicate_detect(z, 3)
+#'
+#' # ---------------------------------------------------------------------------
+#'
+#' # rray_duplicate_id() returns the location
+#' # of the first occurance along each axis.
+#' # Compare to rray_duplicate_detect()!
+#' rray_duplicate_detect(z, 1)
+#' rray_duplicate_id(z, 1)
 #'
 #' @name rray_duplicate
 #' @export

--- a/R/duplicate.R
+++ b/R/duplicate.R
@@ -76,48 +76,123 @@
 #'
 #' @name rray_duplicate
 #' @export
-rray_duplicate_any <- function(x, axis = 1L) {
+rray_duplicate_any <- function(x, axes = NULL) {
 
-  axis <- vec_cast(axis, integer())
-  validate_axis(axis, x)
+  axes <- check_duplicate_axes(axes, x)
 
-  if (identical(axis, 1L)) {
-    return(vec_duplicate_any(x))
-  }
+  x_split_flat <- duplicate_splitter(x, axes)
 
-  x <- rray_rotate(x, from = axis, to = 1L)
+  flat_res <- map_lgl(x_split_flat, vec_duplicate_any)
 
-  vec_duplicate_any(x)
+  res <- keep_dims(flat_res, x, axes)
+
+  new_dim_names <- restore_dim_names(dim_names(x), vec_dim(res))
+  res <- set_full_dim_names(res, new_dim_names)
+
+  vec_restore(res, x)
 }
 
 #' @rdname rray_duplicate
 #' @export
-rray_duplicate_detect <- function(x, axis = 1L) {
+rray_duplicate_detect <- function(x, axes = NULL) {
 
-  axis <- vec_cast(axis, integer())
-  validate_axis(axis, x)
+  axes <- check_duplicate_axes(axes, x)
 
-  if (identical(axis, 1L)) {
-    return(vec_duplicate_detect(x))
-  }
+  x_split_flat <- duplicate_splitter(x, axes)
 
-  x <- rray_rotate(x, from = axis, to = 1L)
+  res_lgl_lst <- map(x_split_flat, vec_duplicate_detect)
 
-  vec_duplicate_detect(x)
+  res_flat <- rray_unlist(res_lgl_lst)
+
+  res <- restore_shape(res_flat, vec_dim(x), axes)
+
+  res <- set_full_dim_names(res, dim_names(x))
+
+  vec_restore(res, x)
 }
 
 #' @rdname rray_duplicate
 #' @export
-rray_duplicate_id <- function(x, axis = 1L) {
+rray_duplicate_id <- function(x, axes = NULL) {
 
-  axis <- vec_cast(axis, integer())
-  validate_axis(axis, x)
+  axes <- check_duplicate_axes(axes, x)
 
-  if (identical(axis, 1L)) {
-    return(vec_duplicate_id(x))
+  x_split_flat <- duplicate_splitter(x, axes)
+
+  res_lgl_lst <- map(x_split_flat, vec_duplicate_id)
+
+  res_flat <- rray_unlist(res_lgl_lst)
+
+  res <- restore_shape(res_flat, vec_dim(x), axes)
+
+  res <- set_full_dim_names(res, dim_names(x))
+
+  vec_restore(res, x)
+}
+
+# ------------------------------------------------------------------------------
+
+check_duplicate_axes <- function(axes, x) {
+  axes <- vec_cast(axes, integer())
+  validate_axes(axes, x)
+
+  # should work for NULL and integer(0) cases
+  if (any(diff(axes) <= 0L)) {
+    glubort("`axes` must be unique and in ascending order.")
   }
 
-  x <- rray_rotate(x, from = axis, to = 1L)
+  if (is.null(axes)) {
+    axes <- seq_len(vec_dims(x))
+  }
 
-  vec_duplicate_id(x)
+  axes
+}
+
+rray_unlist <- function(x) {
+  unlist(x, recursive = FALSE, use.names = FALSE)
+}
+
+duplicate_splitter <- function(x, axes) {
+
+  axes_complement <- get_axes_complement(vec_dims(x), axes)
+
+  # Get reversed complement of axes
+  # These are used to split with
+  axes_complement_rev <- rev(axes_complement)
+
+  x_split <- rray_split(x, axes_complement_rev)
+
+  # Flatten because we need to treat each row as a vector, not as a single row
+  # otherwise the vctrs functions return 1 value per row
+  x_split_flat <- map(x_split, as.vector)
+
+  x_split_flat
+}
+
+# flat -> correct shape
+# by first pulling axes of interest to the front
+# in a reshape, then transposing to undo
+restore_shape <- function(x, dim, axes) {
+
+  dims <- length(dim)
+
+  axes_complement <- get_axes_complement(dims, axes)
+
+  permutation <- c(axes, axes_complement)
+
+  out <- rray_reshape(x, dim[permutation])
+  out <- rray_transpose(out, order(permutation))
+
+  out
+}
+
+get_axes_complement <- function(dims, axes) {
+  axes_seq <- seq_len(dims)
+
+  if (length(axes) == 0L) {
+    axes_seq
+  }
+  else {
+    axes_seq[-axes]
+  }
 }

--- a/man/rray_duplicate.Rd
+++ b/man/rray_duplicate.Rd
@@ -7,34 +7,27 @@
 \alias{rray_duplicate_id}
 \title{Find duplicated values in an array}
 \usage{
-rray_duplicate_any(x, axis = 1L)
+rray_duplicate_any(x, axes = NULL)
 
-rray_duplicate_detect(x, axis = 1L)
+rray_duplicate_detect(x, axes = NULL)
 
-rray_duplicate_id(x, axis = 1L)
+rray_duplicate_id(x, axes = NULL)
 }
 \arguments{
 \item{x}{A vector, matrix, array, or rray.}
 
-\item{axis}{A single integer. The axis to look for duplicate values over.}
-}
-\value{
-\itemize{
-\item \code{rray_duplicate_any()}: a logical vector of length 1.
-\item \code{rray_duplicate_detect()}: a logical vector the same length as \code{x}.
-\item \code{rray_duplicate_id()}: an integer vector the same length as \code{x}.
-}
+\item{axes}{An integer vector. The default of \code{NULL} looks for duplicates
+over all axes.}
 }
 \description{
 \itemize{
-\item \code{rray_duplicate_any()}: detects the presence of duplicated values,
-similar to \code{\link[=anyDuplicated]{anyDuplicated()}} with the \code{MARGIN} argument.
-\item \code{rray_duplicate_detect()}: returns a logical vector describing if each
-element of the vector is duplicated elsewhere. It is similar to
-\code{\link[=duplicated]{duplicated()}} with the \code{MARGIN} argument, but it reports all duplicated
-values, not just the second and subsequent repetitions.
-\item \code{rray_duplicate_id()}: returns an integer vector giving the location of the
-first occurence of the value.
+\item \code{rray_duplicate_any()}: returns a logical with the same shape and type
+as \code{x} except over the \code{axes}, which will be reduced to length 1. This
+function detects the presence of any duplicated values along the \code{axes}.
+\item \code{rray_duplicate_detect()}: returns a logical with the same shape and
+type as \code{x} describing if that element of \code{x} is duplicated elsewhere.
+\item \code{rray_duplicate_id()}: returns an integer with the same shape and
+type as \code{x} giving the location of the first occurence of the value.
 }
 }
 \examples{
@@ -52,31 +45,32 @@ rray_duplicate_any(x, 2L)
 # where the columns are not unique
 y <- rray_expand_dims(x, 1)
 
-# All of the rows are unique...
+# Along the rows, all the values are unique...
 rray_duplicate_any(y, 1L)
 
-# ...but the columns are not
+# ...but along the columns there are duplicates
 rray_duplicate_any(y, 2L)
 
-# rray_duplicate_detect() returns
-# `TRUE` if a duplicate is detected
-# anywhere in the array (both
-# columns are registered as
-# duplicates)
-rray_duplicate_detect(y, 2)
+# ---------------------------------------------------------------------------
 
-# duplicated() only returns `TRUE`
-# for the second and all subsequent
-# duplicates
-duplicated(as_array(y), MARGIN = 2L)
+z <- rray(c(1, 1, 2, 3, 1, 4, 5, 6), c(2, 2, 2))
 
-# Find the location of the
-# first unique values
-rray_duplicate_id(y, 2L)
+# rray_duplicate_detect() looks for any
+# duplicates along the axes of interest
+# and returns `TRUE` wherever a duplicate is found
+# (including the first location)
+rray_duplicate_detect(z, 1)
 
-# Both of the 3rd dimension elements
-# are unique
-rray_duplicate_id(y, 3L)
+# Positions 1 and 5 are the same!
+rray_duplicate_detect(z, 3)
+
+# ---------------------------------------------------------------------------
+
+# rray_duplicate_id() returns the location
+# of the first occurance along each axis.
+# Compare to rray_duplicate_detect()!
+rray_duplicate_detect(z, 1)
+rray_duplicate_id(z, 1)
 
 }
 \seealso{

--- a/tests/testthat/test-duplicate.R
+++ b/tests/testthat/test-duplicate.R
@@ -1,61 +1,228 @@
-context("test-duplicate")
+# This `x` is complex enough that it hits most of the complexity of
+# transposing / reshaping
 
-test_that("duplicates along `axis = 1` is equal to vctrs", {
-  x <- c(1, 1, 2, 2, 3)
-  expect_equal(rray_duplicate_any(x), vec_duplicate_any(x))
-  expect_equal(rray_duplicate_detect(x), vec_duplicate_detect(x))
-  expect_equal(rray_duplicate_id(x), vec_duplicate_id(x))
+# ------------------------------------------------------------------------------
+context("test-duplicate-any")
 
-  x <- rray(c(1, 1, 2, 2), c(2, 2))
-  expect_equal(rray_duplicate_any(x), vec_duplicate_any(x))
-  expect_equal(rray_duplicate_detect(x), vec_duplicate_detect(x))
-  expect_equal(rray_duplicate_id(x), vec_duplicate_id(x))
+test_that("along 1 axis works", {
+  x <- array(c(1, 4, 1, 3, 3, 1, 4, 4, 4, 6, 7, 1), c(2, 3, 2))
+
+  expect_equal(vec_dim(rray_duplicate_any(x, 1)), c(1, 3, 2))
+  expect_equal(vec_dim(rray_duplicate_any(x, 2)), c(2, 1, 2))
+  expect_equal(vec_dim(rray_duplicate_any(x, 3)), c(2, 3, 1))
+
+  expect_equal(rray_duplicate_any(x, 1), new_array(c(F, F, F, T, F, F), c(1, 3, 2)))
+  expect_equal(rray_duplicate_any(x, 2), new_array(c(T, F, T, F),       c(2, 1, 2)))
+  expect_equal(rray_duplicate_any(x, 3), new_array(c(F, T, F, F, F, T), c(2, 3, 1)))
 })
 
-test_that("can compute duplicates along columns", {
+test_that("along 2 axes works", {
+  x <- array(c(1, 4, 1, 3, 3, 1, 4, 4, 4, 6, 7, 1), c(2, 3, 2))
 
-  x <- rray(c(1, 1, 2, 2), c(1, 4))
+  expect_equal(vec_dim(rray_duplicate_any(x, c(1, 2))), c(1, 1, 2))
+  expect_equal(vec_dim(rray_duplicate_any(x, c(1, 3))), c(1, 3, 1))
+  expect_equal(vec_dim(rray_duplicate_any(x, c(2, 3))), c(2, 1, 1))
 
-  expect_true(
-    rray_duplicate_any(x, axis = 2L),
-  )
+  expect_equal(rray_duplicate_any(x, c(1, 2)), new_array(c(T, T),    c(1, 1, 2)))
+  expect_equal(rray_duplicate_any(x, c(1, 3)), new_array(c(T, F, T), c(1, 3, 1)))
+  expect_equal(rray_duplicate_any(x, c(2, 3)), new_array(c(T, T),    c(2, 1, 1)))
+})
 
-  expect_equal(
-    rray_duplicate_detect(x, 2),
-    rep(TRUE, times = 4)
-  )
+test_that("along 3 axes works", {
+  x <- array(c(1, 4, 1, 3, 3, 1, 4, 4, 4, 6, 7, 1), c(2, 3, 2))
 
-  expect_equal(
-    rray_duplicate_detect(x, 1),
-    FALSE
-  )
+  expect_equal(vec_dim(rray_duplicate_any(x, c(1, 2, 3))), c(1, 1, 1))
 
-  expect_equal(
-    rray_duplicate_id(x, 2),
-    c(1, 1, 3, 3)
-  )
-
+  expect_equal(rray_duplicate_any(x, c(1, 2, 3)), new_array(T, c(1, 1, 1)))
 })
 
 test_that("`axis` is validated", {
-  axis <- c(1, 2)
-  expect_error(rray_duplicate_any(1, axis), "Invalid `axis`")
-  expect_error(rray_duplicate_detect(1, axis), "Invalid `axis`")
-  expect_error(rray_duplicate_id(1, axis), "Invalid `axis`")
-
   axis <- -1
-  expect_error(rray_duplicate_any(1, axis), "Invalid `axis`")
-  expect_error(rray_duplicate_detect(1, axis), "Invalid `axis`")
-  expect_error(rray_duplicate_id(1, axis), "Invalid `axis`")
+  expect_error(rray_duplicate_any(1, axis), "Invalid `axes`")
 
   axis <- 2
-  expect_error(rray_duplicate_any(1, axis), "Invalid `axis`")
-  expect_error(rray_duplicate_detect(1, axis), "Invalid `axis`")
-  expect_error(rray_duplicate_id(1, axis), "Invalid `axis`")
+  expect_error(rray_duplicate_any(1, axis), "Invalid `axes`")
 })
 
-test_that("`NULL` input", {
-  expect_equal(rray_duplicate_any(NULL, 2L), FALSE)
-  expect_equal(rray_duplicate_detect(NULL, 2L), logical(0))
-  expect_equal(rray_duplicate_id(NULL, 2L), integer(0))
+
+test_that("`NULL` axes", {
+  x <- array(c(1, 4, 1, 3, 3, 1, 4, 4, 4, 6, 7, 1), c(2, 3, 2))
+  expect_equal(
+    rray_duplicate_any(x, axes = NULL),
+    rray_duplicate_any(x, axes = seq_len(vec_dims(x)))
+  )
 })
+
+# no reduction is done. treats each cell individually, so there can't be dups
+test_that("length 0 integer axes", {
+  x <- array(c(1, 4, 1, 3, 3, 1, 4, 4, 4, 6, 7, 1), c(2, 3, 2))
+  expect_equal(
+    rray_duplicate_any(x, axes = integer()),
+    new_array(FALSE, c(2, 3, 2))
+  )
+})
+
+test_that("names are kept", {
+  x <- matrix(1, dimnames = list("c1", "c2"))
+  expect_equal(dim_names(rray_duplicate_any(x)), dim_names(x))
+})
+
+test_that("`axes` must be ordered and unique", {
+  expect_error(rray_duplicate_any(matrix(1), c(2, 1)), "in ascending order")
+  expect_error(rray_duplicate_any(matrix(1), c(2, 2)), "in ascending order")
+})
+
+test_that("rray class is kept", {
+  expect_equal(rray_duplicate_any(rray(1), 1), rray(FALSE))
+})
+
+# ------------------------------------------------------------------------------
+context("test-duplicate-detect")
+
+test_that("along 1 axis works", {
+  x <- array(c(1, 4, 1, 3, 3, 1, 4, 4, 4, 6, 7, 1), c(2, 3, 2))
+
+  expect_equal(vec_dim(rray_duplicate_detect(x, 1)), c(2, 3, 2))
+  expect_equal(vec_dim(rray_duplicate_detect(x, 2)), c(2, 3, 2))
+  expect_equal(vec_dim(rray_duplicate_detect(x, 3)), c(2, 3, 2))
+
+  expect_equal(rray_duplicate_detect(x, 1), new_array(c(F, F, F, F, F, F, T, T, F, F, F, F), c(2, 3, 2)))
+  expect_equal(rray_duplicate_detect(x, 2), new_array(c(T, F, T, F, F, F, T, F, T, F, F, F), c(2, 3, 2)))
+  expect_equal(rray_duplicate_detect(x, 3), new_array(c(F, T, F, F, F, T, F, T, F, F, F, T), c(2, 3, 2)))
+})
+
+test_that("along 2 axes works", {
+  x <- array(c(1, 4, 1, 3, 3, 1, 4, 4, 4, 6, 7, 1), c(2, 3, 2))
+
+  expect_equal(vec_dim(rray_duplicate_detect(x, c(1, 2))), c(2, 3, 2))
+  expect_equal(vec_dim(rray_duplicate_detect(x, c(1, 3))), c(2, 3, 2))
+  expect_equal(vec_dim(rray_duplicate_detect(x, c(2, 3))), c(2, 3, 2))
+
+  expect_equal(rray_duplicate_detect(x, c(1, 2)), new_array(c(T, F, T, T, T, T, T, T, T, F, F, F), c(2, 3, 2)))
+  expect_equal(rray_duplicate_detect(x, c(1, 3)), new_array(c(F, T, F, F, F, T, T, T, F, F, F, T), c(2, 3, 2)))
+  expect_equal(rray_duplicate_detect(x, c(2, 3)), new_array(c(T, T, T, F, F, T, T, T, T, F, F, T), c(2, 3, 2)))
+})
+
+test_that("along 3 axes works", {
+  x <- array(c(1, 4, 1, 3, 3, 1, 4, 4, 4, 6, 7, 1), c(2, 3, 2))
+
+  expect_equal(vec_dim(rray_duplicate_detect(x, c(1, 2, 3))), c(2, 3, 2))
+
+  expect_equal(rray_duplicate_detect(x, c(1, 2, 3)), new_array(c(T, T, T, T, T, T, T, T, T, F, F, T), c(2, 3, 2)))
+})
+
+test_that("`axis` is validated", {
+  axis <- -1
+  expect_error(rray_duplicate_detect(1, axis), "Invalid `axes`")
+
+  axis <- 2
+  expect_error(rray_duplicate_detect(1, axis), "Invalid `axes`")
+})
+
+
+test_that("`NULL` axes", {
+  x <- array(c(1, 4, 1, 3, 3, 1, 4, 4, 4, 6, 7, 1), c(2, 3, 2))
+  expect_equal(
+    rray_duplicate_detect(x, axes = NULL),
+    rray_duplicate_detect(x, axes = seq_len(vec_dims(x)))
+  )
+})
+
+# no reduction is done. treats each cell individually, so there can't be dups
+test_that("length 0 integer axes", {
+  x <- array(c(1, 4, 1, 3, 3, 1, 4, 4, 4, 6, 7, 1), c(2, 3, 2))
+  expect_equal(
+    rray_duplicate_detect(x, axes = integer()),
+    new_array(FALSE, c(2, 3, 2))
+  )
+})
+
+test_that("names are kept", {
+  x <- matrix(1, dimnames = list("c1", "c2"))
+  expect_equal(dim_names(rray_duplicate_detect(x)), dim_names(x))
+})
+
+test_that("`axes` must be ordered and unique", {
+  expect_error(rray_duplicate_detect(matrix(1), c(2, 1)), "in ascending order")
+  expect_error(rray_duplicate_detect(matrix(1), c(2, 2)), "in ascending order")
+})
+
+test_that("rray class is kept", {
+  expect_equal(rray_duplicate_detect(rray(1), 1), rray(FALSE))
+})
+
+# ------------------------------------------------------------------------------
+context("test-duplicate-id")
+
+test_that("along 1 axis works", {
+  x <- array(c(1, 4, 1, 3, 3, 1, 4, 4, 4, 6, 7, 1), c(2, 3, 2))
+
+  expect_equal(vec_dim(rray_duplicate_id(x, 1)), c(2, 3, 2))
+  expect_equal(vec_dim(rray_duplicate_id(x, 2)), c(2, 3, 2))
+  expect_equal(vec_dim(rray_duplicate_id(x, 3)), c(2, 3, 2))
+
+  expect_equal(rray_duplicate_id(x, 1), new_array(c(1, 2, 1, 2, 1, 2, 1, 1, 1, 2, 1, 2), c(2, 3, 2)))
+  expect_equal(rray_duplicate_id(x, 2), new_array(c(1, 1, 1, 2, 3, 3, 1, 1, 1, 2, 3, 3), c(2, 3, 2)))
+  expect_equal(rray_duplicate_id(x, 3), new_array(c(1, 1, 1, 1, 1, 1, 2, 1, 2, 2, 2, 1), c(2, 3, 2)))
+})
+
+test_that("along 2 axes works", {
+  x <- array(c(1, 4, 1, 3, 3, 1, 4, 4, 4, 6, 7, 1), c(2, 3, 2))
+
+  expect_equal(vec_dim(rray_duplicate_id(x, c(1, 2))), c(2, 3, 2))
+  expect_equal(vec_dim(rray_duplicate_id(x, c(1, 3))), c(2, 3, 2))
+  expect_equal(vec_dim(rray_duplicate_id(x, c(2, 3))), c(2, 3, 2))
+
+  expect_equal(rray_duplicate_id(x, c(1, 2)), new_array(c(1, 2, 1, 4, 4, 1, 1, 1, 1, 4, 5, 6), c(2, 3, 2)))
+  expect_equal(rray_duplicate_id(x, c(1, 3)), new_array(c(1, 2, 1, 2, 1, 2, 2, 2, 3, 4, 3, 2), c(2, 3, 2)))
+  expect_equal(rray_duplicate_id(x, c(2, 3)), new_array(c(1, 1, 1, 2, 3, 3, 4, 1, 4, 5, 6, 3), c(2, 3, 2)))
+})
+
+test_that("along 3 axes works", {
+  x <- array(c(1, 4, 1, 3, 3, 1, 4, 4, 4, 6, 7, 1), c(2, 3, 2))
+
+  expect_equal(vec_dim(rray_duplicate_id(x, c(1, 2, 3))), c(2, 3, 2))
+
+  expect_equal(rray_duplicate_id(x, c(1, 2, 3)), new_array(c(1, 2, 1, 4, 4, 1, 2, 2, 2, 10, 11, 1), c(2, 3, 2)))
+})
+
+test_that("`axis` is validated", {
+  axis <- -1
+  expect_error(rray_duplicate_id(1, axis), "Invalid `axes`")
+
+  axis <- 2
+  expect_error(rray_duplicate_id(1, axis), "Invalid `axes`")
+})
+
+
+test_that("`NULL` axes", {
+  x <- array(c(1, 4, 1, 3, 3, 1, 4, 4, 4, 6, 7, 1), c(2, 3, 2))
+  expect_equal(
+    rray_duplicate_id(x, axes = NULL),
+    rray_duplicate_id(x, axes = seq_len(vec_dims(x)))
+  )
+})
+
+# no reduction is done. treats each cell individually, so there can't be dups
+test_that("length 0 integer axes", {
+  x <- array(c(1, 4, 1, 3, 3, 1, 4, 4, 4, 6, 7, 1), c(2, 3, 2))
+  expect_equal(
+    rray_duplicate_id(x, axes = integer()),
+    new_array(1, c(2, 3, 2))
+  )
+})
+
+test_that("names are kept", {
+  x <- matrix(1, dimnames = list("c1", "c2"))
+  expect_equal(dim_names(rray_duplicate_id(x)), dim_names(x))
+})
+
+test_that("`axes` must be ordered and unique", {
+  expect_error(rray_duplicate_id(matrix(1), c(2, 1)), "in ascending order")
+  expect_error(rray_duplicate_id(matrix(1), c(2, 2)), "in ascending order")
+})
+
+test_that("rray class is kept", {
+  expect_equal(rray_duplicate_id(rray(1), 1), rray(1L))
+})
+


### PR DESCRIPTION
After extensive discussion in #149, this PR implements a (hopefully) correct version of the duplicate functions.

They are currently much slower than they need to be, but I'm happy to have a working implementation and a much larger test suite for these functions. Speed can come later.