### PR TITLE
Split

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -133,8 +133,16 @@ rray__if_else <- function(condition, true_, false_) {
     .Call(`_rray_rray__if_else`, condition, true_, false_)
 }
 
-rray__split <- function(x, n, axis) {
-    .Call(`_rray_rray__split`, x, n, axis)
+rray__new_empty_dim_names <- function(n) {
+    .Call(`_rray_rray__new_empty_dim_names`, n)
+}
+
+rray__dim_names <- function(x) {
+    .Call(`_rray_rray__dim_names`, x)
+}
+
+rray__split <- function(x, axes) {
+    .Call(`_rray_rray__split`, x, axes)
 }
 
 rray__rotate <- function(x, from, to, n) {

--- a/R/duplicate.R
+++ b/R/duplicate.R
@@ -149,11 +149,7 @@ duplicate_splitter <- function(x, axes) {
 
   axes_complement <- get_axes_complement(vec_dims(x), axes)
 
-  # Get reversed complement of axes
-  # These are used to split with
-  axes_complement_rev <- rev(axes_complement)
-
-  x_split <- rray_split(x, axes_complement_rev)
+  x_split <- rray_split(x, axes_complement)
 
   # Flatten because we need to treat each row as a vector, not as a single row
   # otherwise the vctrs functions return 1 value per row

--- a/R/split.R
+++ b/R/split.R
@@ -85,14 +85,7 @@ rray_split <- function(x, axes = NULL) {
 
   res <- rray__split(x, as_cpp_idx(axes))
 
-  # All non-axes dim names are the same
-  # axes dim names are split up over the axes
-  # new_dim_names_lst <- split_dim_names(dim_names(x), axes, n)
-
-  # Use anonymous function to work around dispatch bug with internal generics
-  #res <- map2(res, new_dim_names_lst, function(x, nms) {set_full_dim_names(x, nms)})
-
-  #res <- map(res, vec_restore, to = x)
+  res <- map(res, vec_restore, to = x)
 
   res
 }

--- a/R/split.R
+++ b/R/split.R
@@ -5,50 +5,48 @@
 #' @param x A vector, matrix, array, or rray.
 #'
 #' @param axes An integer vector. The axes to split on. The default splits
-#' along all axes, and does so in reverse order, which produces the most
-#' intuitive result.
+#' along all axes.
 #'
-#' @param n An integer vector, or `NULL`. By default, this is computed as the
-#' dimension size of each axis specified in `axes`. If not `NULL`, it should
-#' be the same length as `axes`.
+#' @details
+#'
+#' `rray_split()` works by splitting along the `axes`. The result is a list
+#' of sub arrays, where the `axes` of each sub array have been reduced to
+#' length 1. This is consistent with how reducers like [rray_sum()] work. As
+#' an example, splitting a `(2, 3, 5)` array along `axes = c(2, 3)` would
+#' result in a list of 15 (from `3 * 5`) sub arrays, each with
+#' shape `(2, 1, 1)`.
 #'
 #' @return
 #'
-#' A list of equal pieces of type `x`.
+#' A list of sub arrays of type `x`.
 #'
 #' @examples
 #'
 #' x <- matrix(1:8, ncol = 2)
 #'
 #' # Split the rows
+#' # (4, 2) -> (1, 2)
 #' rray_split(x, 1)
 #'
 #' # Split the columns
+#' # (4, 2) -> (4, 1)
 #' rray_split(x, 2)
 #'
 #' # Split along multiple dimensions
-#' # To have them in the most interpretable
-#' # order, split backwards along the dimensions
-#' # (i.e. 2 then 1)
-#' rray_split(x, c(2, 1))
+#' # (4, 2) -> (1, 1)
+#' rray_split(x, c(1, 2))
 #'
-#' # The above split is what the default behavior does
+#' # The above split is the default behavior
 #' rray_split(x)
-#'
-#' # Split along rows in chunks of 2
-#' rray_split(x, 1, 2)
-#'
-#' # Split along columns and then
-#' # rows in chunks of 2
-#' rray_split(x, c(2, 1), c(2, 2))
 #'
 #' # You can technically split with a size 0 `axes`
 #' # argument, which essentially requests no axes
 #' # to be split and is the same as `list(x)`
 #' rray_split(x, axes = integer(0))
 #'
-#'
+#' # ---------------------------------------------------------------------------
 #' # 4 dimensional example
+#'
 #' x_4d <- rray(
 #'   x = 1:16,
 #'   dim = c(2, 2, 2, 2),
@@ -61,17 +59,17 @@
 #' )
 #'
 #' # Split along the 1st dimension (rows)
-#' # End up with 2 equal sized elements
+#' # (2, 2, 2, 2) -> (1, 2, 2, 2)
 #' rray_split(x_4d, 1)
 #'
 #' # Split along columns
+#' # (2, 2, 2, 2) -> (2, 1, 2, 2)
 #' rray_split(x_4d, 2)
 #'
 #' # Probably the most useful thing you might do
 #' # is use this to split the 4D array into a set
-#' # of 4 2D matrices. To have them in order
-#' # split by the 4th dimension, then the 3rd.
-#' rray_split(x_4d, c(4, 3))
+#' # of 4 2D matrices.
+#' rray_split(x_4d, c(3, 4))
 #'
 #' @export
 rray_split <- function(x, axes = NULL) {

--- a/man/rray_split.Rd
+++ b/man/rray_split.Rd
@@ -4,58 +4,55 @@
 \alias{rray_split}
 \title{Split an array along axes}
 \usage{
-rray_split(x, axes = NULL, n = NULL)
+rray_split(x, axes = NULL)
 }
 \arguments{
 \item{x}{A vector, matrix, array, or rray.}
 
 \item{axes}{An integer vector. The axes to split on. The default splits
-along all axes, and does so in reverse order, which produces the most
-intuitive result.}
-
-\item{n}{An integer vector, or \code{NULL}. By default, this is computed as the
-dimension size of each axis specified in \code{axes}. If not \code{NULL}, it should
-be the same length as \code{axes}.}
+along all axes.}
 }
 \value{
-A list of equal pieces of type \code{x}.
+A list of sub arrays of type \code{x}.
 }
 \description{
 \code{rray_split()} splits \code{x} into equal pieces, splitting along the \code{axes}.
+}
+\details{
+\code{rray_split()} works by splitting along the \code{axes}. The result is a list
+of sub arrays, where the \code{axes} of each sub array have been reduced to
+length 1. This is consistent with how reducers like \code{\link[=rray_sum]{rray_sum()}} work. As
+an example, splitting a \code{(2, 3, 5)} array along \code{axes = c(2, 3)} would
+result in a list of 15 (from \code{3 * 5}) sub arrays, each with
+shape \code{(2, 1, 1)}.
 }
 \examples{
 
 x <- matrix(1:8, ncol = 2)
 
 # Split the rows
+# (4, 2) -> (1, 2)
 rray_split(x, 1)
 
 # Split the columns
+# (4, 2) -> (4, 1)
 rray_split(x, 2)
 
 # Split along multiple dimensions
-# To have them in the most interpretable
-# order, split backwards along the dimensions
-# (i.e. 2 then 1)
-rray_split(x, c(2, 1))
+# (4, 2) -> (1, 1)
+rray_split(x, c(1, 2))
 
-# The above split is what the default behavior does
+# The above split is the default behavior
 rray_split(x)
-
-# Split along rows in chunks of 2
-rray_split(x, 1, 2)
-
-# Split along columns and then
-# rows in chunks of 2
-rray_split(x, c(2, 1), c(2, 2))
 
 # You can technically split with a size 0 `axes`
 # argument, which essentially requests no axes
 # to be split and is the same as `list(x)`
 rray_split(x, axes = integer(0))
 
-
+# ---------------------------------------------------------------------------
 # 4 dimensional example
+
 x_4d <- rray(
   x = 1:16,
   dim = c(2, 2, 2, 2),
@@ -68,16 +65,16 @@ x_4d <- rray(
 )
 
 # Split along the 1st dimension (rows)
-# End up with 2 equal sized elements
+# (2, 2, 2, 2) -> (1, 2, 2, 2)
 rray_split(x_4d, 1)
 
 # Split along columns
+# (2, 2, 2, 2) -> (2, 1, 2, 2)
 rray_split(x_4d, 2)
 
 # Probably the most useful thing you might do
 # is use this to split the 4D array into a set
-# of 4 2D matrices. To have them in order
-# split by the 4th dimension, then the 3rd.
-rray_split(x_4d, c(4, 3))
+# of 4 2D matrices.
+rray_split(x_4d, c(3, 4))
 
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -365,15 +365,34 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// rray__new_empty_dim_names
+Rcpp::List rray__new_empty_dim_names(int n);
+RcppExport SEXP _rray_rray__new_empty_dim_names(SEXP nSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< int >::type n(nSEXP);
+    rcpp_result_gen = Rcpp::wrap(rray__new_empty_dim_names(n));
+    return rcpp_result_gen;
+END_RCPP
+}
+// rray__dim_names
+Rcpp::List rray__dim_names(const Rcpp::RObject& x);
+RcppExport SEXP _rray_rray__dim_names(SEXP xSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type x(xSEXP);
+    rcpp_result_gen = Rcpp::wrap(rray__dim_names(x));
+    return rcpp_result_gen;
+END_RCPP
+}
 // rray__split
-Rcpp::RObject rray__split(Rcpp::RObject x, std::size_t n, std::size_t axis);
-RcppExport SEXP _rray_rray__split(SEXP xSEXP, SEXP nSEXP, SEXP axisSEXP) {
+Rcpp::RObject rray__split(Rcpp::RObject x, const std::vector<std::size_t>& axes);
+RcppExport SEXP _rray_rray__split(SEXP xSEXP, SEXP axesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< Rcpp::RObject >::type x(xSEXP);
-    Rcpp::traits::input_parameter< std::size_t >::type n(nSEXP);
-    Rcpp::traits::input_parameter< std::size_t >::type axis(axisSEXP);
-    rcpp_result_gen = Rcpp::wrap(rray__split(x, n, axis));
+    Rcpp::traits::input_parameter< const std::vector<std::size_t>& >::type axes(axesSEXP);
+    rcpp_result_gen = Rcpp::wrap(rray__split(x, axes));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1051,7 +1070,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rray_rray__any", (DL_FUNC) &_rray_rray__any, 2},
     {"_rray_rray__all", (DL_FUNC) &_rray_rray__all, 2},
     {"_rray_rray__if_else", (DL_FUNC) &_rray_rray__if_else, 3},
-    {"_rray_rray__split", (DL_FUNC) &_rray_rray__split, 3},
+    {"_rray_rray__new_empty_dim_names", (DL_FUNC) &_rray_rray__new_empty_dim_names, 1},
+    {"_rray_rray__dim_names", (DL_FUNC) &_rray_rray__dim_names, 1},
+    {"_rray_rray__split", (DL_FUNC) &_rray_rray__split, 2},
     {"_rray_rray__rotate", (DL_FUNC) &_rray_rray__rotate, 4},
     {"_rray_rray__transpose", (DL_FUNC) &_rray_rray__transpose, 2},
     {"_rray_rray__squeeze", (DL_FUNC) &_rray_rray__squeeze, 2},

--- a/src/manipulation.cpp
+++ b/src/manipulation.cpp
@@ -3,67 +3,6 @@
 
 // -----------------------------------------------------------------------------
 
-// xt_split() splits `e` along `axes`. For example, it does:
-// x <- array(1:8, c(2, 2, 2))
-// rray_split(x, c(1, 2)) # (0, 1) cpp axes
-// x[1, 1, all()]
-// x[2, 1, all()]
-// x[1, 2, all()]
-// x[2, 2, all()]
-
-// No `n` for now.
-// Assume `n` splits it so that the step = 1
-
-// idx updating adapted from
-// https://stackoverflow.com/questions/6588487/is-there-a-way-to-iterate-over-an-n-dimensional-array-where-n-is-variable-with
-
-template <class E>
-auto xt_split(E& e, const std::vector<std::size_t>& axes) {
-
-  // Initially fill the slice vector with all()
-  xt::xstrided_slice_vector sv(e.dimension(), xt::all());
-
-  // Construct the result vector of strided view
-  std::vector<decltype(xt::strided_view(e, sv))> result;
-
-  int n_axes = axes.size();
-
-  // Container for keeping track of current axes indices
-  std::vector<int> idxs(n_axes);
-
-  // Get the shape of the axes
-  auto shape = e.shape();
-  std::vector<std::size_t> shape_axes(n_axes);
-  for (int i = 0; i < n_axes; ++i) {
-    shape_axes[i] = shape[axes[i]];
-  }
-
-  // essentially same as prod(shape_axes)
-  int n_elems = std::accumulate(
-    begin(shape_axes), end(shape_axes),
-    1, std::multiplies<int>()
-  );
-
-  for (int n = 0; n < n_elems; ++n) {
-
-    // Add strided view
-    for (int i = 0; i < n_axes; ++i) {
-      sv[axes[i]] = xt::range(idxs[i], (idxs[i] + 1));
-    }
-    result.emplace_back(xt::strided_view(e, sv));
-
-    // Update idxs
-    for (int j = 0; j < n_axes; ++j) {
-      idxs[j]++;
-      if (idxs[j] < shape_axes[j]) break;
-      idxs[j] = 0;
-    }
-
-  }
-
-  return result;
-}
-
 // [[Rcpp::export(rng = false)]]
 Rcpp::List rray__new_empty_dim_names(int n) {
   return Rcpp::List(n);
@@ -100,41 +39,133 @@ Rcpp::List rray__dim_names(const Rcpp::RObject& x) {
   return Rcpp::as<Rcpp::List>(x_dim_names);
 }
 
-Rcpp::List split_dim_names(const Rcpp::List& dim_names,
-                           const std::vector<std::size_t>& axes) {
+// -----------------------------------------------------------------------------
 
-  Rcpp::List dim_names_copy = Rcpp::clone(dim_names);
+// xt_split() splits `e` along `axes`. For example, it does:
+// x <- array(1:8, c(2, 2, 2))
+// rray_split(x, c(1, 2)) # (0, 1) cpp axes
+// x[1, 1, all()]
+// x[2, 1, all()]
+// x[1, 2, all()]
+// x[2, 2, all()]
 
-  for (std::size_t axis : axes) {
-    dim_names_copy[axis] = R_NilValue;
+// No `n` for now.
+// Assume `n` splits it so that the step = 1
+
+// idx updating adapted from
+// https://stackoverflow.com/questions/6588487/is-there-a-way-to-iterate-over-an-n-dimensional-array-where-n-is-variable-with
+
+bool any_not_null_along_axes(const Rcpp::List& x_dim_names,
+                             const std::vector<std::size_t>& axes) {
+  int n_axes = axes.size();
+
+  for (int i = 0; i < n_axes; ++i) {
+    if (!r_is_null(x_dim_names[axes[i]])) {
+      return true;
+    }
   }
 
-  return dim_names_copy;
+  return false;
+}
+
+Rcpp::List split_dim_names(const Rcpp::List& x_dim_names,
+                           const std::vector<std::size_t>& axes,
+                           const std::vector<int>& idxs) {
+
+  // Clone b/c we know from `any_not_null_along_axes()` that at least 1
+  // axis requires splitting
+  Rcpp::List new_dim_names = Rcpp::clone(x_dim_names);
+
+  int n_axes = axes.size();
+
+  for (int i = 0; i < n_axes; ++i) {
+
+    std::size_t axis = axes[i];
+
+    // No dim names along this axis
+    if (r_is_null(new_dim_names[axis])) {
+      continue;
+    }
+
+    int idx = idxs[i];
+
+    // Subset using idx
+    Rcpp::CharacterVector new_axis_names = new_dim_names[axis];
+    new_axis_names = new_axis_names[idx];
+
+    new_dim_names[axis] = new_axis_names;
+  }
+
+  return new_dim_names;
 }
 
 template <typename T>
 Rcpp::List rray__split_impl(const xt::rarray<T>& x,
                             const std::vector<std::size_t>& axes) {
 
-  auto res = xt_split(x, axes);
-  int n = res.size();
+  // Initially fill the slice vector with all()
+  xt::xstrided_slice_vector sv(x.dimension(), xt::all());
 
+  // Construct the result vector of strided view
+  std::vector<decltype(xt::strided_view(x, sv))> result;
+
+  int n_axes = axes.size();
+
+  // Container for keeping track of current axes indices
+  std::vector<int> idxs(n_axes);
+
+  // Get dim names
   Rcpp::List x_dim_names = rray__dim_names(SEXP(x));
-  Rcpp::List new_dim_names = split_dim_names(x_dim_names, axes);
+  bool requires_name_subsetting = any_not_null_along_axes(x_dim_names, axes);
 
-  Rcpp::List out(n);
+  // Get the shape of the axes
+  auto shape = x.shape();
+  std::vector<std::size_t> shape_axes(n_axes);
+  for (int i = 0; i < n_axes; ++i) {
+    shape_axes[i] = shape[axes[i]];
+  }
 
-  for (int i = 0; i < n; ++i) {
-    xt::rarray<T> res_i = res[i];
-    out[i] = res_i;
-    Rf_setAttrib(out[i], R_DimNamesSymbol, new_dim_names);
+  // essentially same as prod(shape_axes)
+  int n_elems = std::accumulate(
+    begin(shape_axes), end(shape_axes),
+    1, std::multiplies<int>()
+  );
+
+  Rcpp::List out(n_elems);
+
+  for (int n = 0; n < n_elems; ++n) {
+
+    // Add strided view
+    for (int i = 0; i < n_axes; ++i) {
+      sv[axes[i]] = xt::range(idxs[i], (idxs[i] + 1));
+    }
+
+    xt::rarray<T> x_view = xt::strided_view(x, sv);
+    out[n] = x_view;
+
+    if (requires_name_subsetting) {
+      Rcpp::List new_dim_names = split_dim_names(x_dim_names, axes, idxs);
+      Rf_setAttrib(out[n], R_DimNamesSymbol, new_dim_names);
+    }
+    else {
+      Rf_setAttrib(out[n], R_DimNamesSymbol, x_dim_names);
+    }
+
+    // Update idxs
+    for (int j = 0; j < n_axes; ++j) {
+      idxs[j]++;
+      if (idxs[j] < shape_axes[j]) break;
+      idxs[j] = 0;
+    }
+
   }
 
   return out;
 }
 
 // [[Rcpp::export(rng = false)]]
-Rcpp::RObject rray__split(Rcpp::RObject x, const std::vector<std::size_t>& axes) {
+Rcpp::RObject rray__split(Rcpp::RObject x,
+                          const std::vector<std::size_t>& axes) {
   DISPATCH_UNARY_ONE(rray__split_impl, x, axes);
 }
 

--- a/src/manipulation.cpp
+++ b/src/manipulation.cpp
@@ -3,29 +3,139 @@
 
 // -----------------------------------------------------------------------------
 
+// xt_split() splits `e` along `axes`. For example, it does:
+// x <- array(1:8, c(2, 2, 2))
+// rray_split(x, c(1, 2)) # (0, 1) cpp axes
+// x[1, 1, all()]
+// x[2, 1, all()]
+// x[1, 2, all()]
+// x[2, 2, all()]
+
+// No `n` for now.
+// Assume `n` splits it so that the step = 1
+
+// idx updating adapted from
+// https://stackoverflow.com/questions/6588487/is-there-a-way-to-iterate-over-an-n-dimensional-array-where-n-is-variable-with
+
+template <class E>
+auto xt_split(E& e, const std::vector<std::size_t>& axes) {
+
+  // Initially fill the slice vector with all()
+  xt::xstrided_slice_vector sv(e.dimension(), xt::all());
+
+  // Construct the result vector of strided view
+  std::vector<decltype(xt::strided_view(e, sv))> result;
+
+  int n_axes = axes.size();
+
+  // Container for keeping track of current axes indices
+  std::vector<int> idxs(n_axes);
+
+  // Get the shape of the axes
+  auto shape = e.shape();
+  std::vector<std::size_t> shape_axes(n_axes);
+  for (int i = 0; i < n_axes; ++i) {
+    shape_axes[i] = shape[axes[i]];
+  }
+
+  // essentially same as prod(shape_axes)
+  int n_elems = std::accumulate(
+    begin(shape_axes), end(shape_axes),
+    1, std::multiplies<int>()
+  );
+
+  for (int n = 0; n < n_elems; ++n) {
+
+    // Add strided view
+    for (int i = 0; i < n_axes; ++i) {
+      sv[axes[i]] = xt::range(idxs[i], (idxs[i] + 1));
+    }
+    result.emplace_back(xt::strided_view(e, sv));
+
+    // Update idxs
+    for (int j = 0; j < n_axes; ++j) {
+      idxs[j]++;
+      if (idxs[j] < shape_axes[j]) break;
+      idxs[j] = 0;
+    }
+
+  }
+
+  return result;
+}
+
+// [[Rcpp::export(rng = false)]]
+Rcpp::List rray__new_empty_dim_names(int n) {
+  return Rcpp::List(n);
+}
+
+bool has_dim(const Rcpp::RObject& x) {
+  return x.hasAttribute("dim");
+}
+
+// [[Rcpp::export(rng = false)]]
+Rcpp::List rray__dim_names(const Rcpp::RObject& x) {
+
+  Rcpp::RObject x_dim_names;
+
+  if (has_dim(x)) {
+    x_dim_names = x.attr("dimnames");
+
+    if (x_dim_names.isNULL()) {
+      x_dim_names = rray__new_empty_dim_names(rray__dims(x));
+    }
+  }
+  else {
+    x_dim_names = x.attr("names");
+
+    if (x_dim_names.isNULL()) {
+      x_dim_names = rray__new_empty_dim_names(rray__dims(x));
+    }
+    else {
+      // character vector -> list
+      x_dim_names = Rcpp::List::create(x_dim_names);
+    }
+  }
+
+  return Rcpp::as<Rcpp::List>(x_dim_names);
+}
+
+Rcpp::List split_dim_names(const Rcpp::List& dim_names,
+                           const std::vector<std::size_t>& axes) {
+
+  Rcpp::List dim_names_copy = Rcpp::clone(dim_names);
+
+  for (std::size_t axis : axes) {
+    dim_names_copy[axis] = R_NilValue;
+  }
+
+  return dim_names_copy;
+}
+
 template <typename T>
 Rcpp::List rray__split_impl(const xt::rarray<T>& x,
-                            std::size_t n,
-                            std::size_t axis) {
+                            const std::vector<std::size_t>& axes) {
 
-  auto res = xt::split(x, n, axis);
+  auto res = xt_split(x, axes);
+  int n = res.size();
+
+  Rcpp::List x_dim_names = rray__dim_names(SEXP(x));
+  Rcpp::List new_dim_names = split_dim_names(x_dim_names, axes);
 
   Rcpp::List out(n);
 
-  // `res` is a vector of strided view
-  // we have to cast each element to an rarray before
-  // assigning into `out`
   for (int i = 0; i < n; ++i) {
     xt::rarray<T> res_i = res[i];
     out[i] = res_i;
+    Rf_setAttrib(out[i], R_DimNamesSymbol, new_dim_names);
   }
 
   return out;
 }
 
 // [[Rcpp::export(rng = false)]]
-Rcpp::RObject rray__split(Rcpp::RObject x, std::size_t n, std::size_t axis) {
-  DISPATCH_UNARY_TWO(rray__split_impl, x, n, axis);
+Rcpp::RObject rray__split(Rcpp::RObject x, const std::vector<std::size_t>& axes) {
+  DISPATCH_UNARY_ONE(rray__split_impl, x, axes);
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/testthat/test-split.R
+++ b/tests/testthat/test-split.R
@@ -94,5 +94,13 @@ test_that("can split with integer(0) axis", {
   expect_equal(rray_split(x, axes = integer()), list(x))
 })
 
+test_that("dim names are in the right order (#161)", {
+  x <- rray(1:6, 2:3, list(A = c("a1", "a2"), B = c("b1", "b2", "b3")))
+  x_split <- rray_split(x, c(1, 2))
+  expect_equal(dim_names(x_split[[1]]), list(A = "a1", B = "b1"))
+  expect_equal(dim_names(x_split[[2]]), list(A = "a2", B = "b1"))
+  expect_equal(dim_names(x_split[[3]]), list(A = "a1", B = "b2"))
+  expect_equal(dim_names(x_split[[5]]), list(A = "a1", B = "b3"))
+})
 
 

--- a/tests/testthat/test-split.R
+++ b/tests/testthat/test-split.R
@@ -16,34 +16,15 @@ test_that("can split 2D `x`", {
   expect_equal(rray_split(x, axes = 2), expect)
 })
 
-test_that("can set `n`", {
-  x <- array(1:8, dim = c(2, 4), dimnames = list(NULL))
-  expect <- list(rray_subset(x, , 1:2), rray_subset(x, , 3:4))
-  expect_equal(rray_split(x, axes = 2, n = 2), expect)
-})
-
 test_that("can split along multiple axes", {
   x <- array(1:8, dim = c(2, 4), dimnames = list(NULL))
 
   # iteration order matters!
-  expect <- rlang::flatten(map(1:4, function(.x) map(1:2, function(.y) {rray_subset(x, .y, .x)})))
+  expect <- rlang::flatten(map(1:2, function(.x) map(1:4, function(.y) {rray_subset(x, .x, .y)})))
   expect_equal(rray_split(x, axes = c(2, 1)), expect)
 
-  expect <- rlang::flatten(map(1:2, function(.x) map(1:4, function(.y) {rray_subset(x, .x, .y)})))
+  expect <- rlang::flatten(map(1:4, function(.x) map(1:2, function(.y) {rray_subset(x, .y, .x)})))
   expect_equal(rray_split(x, axes = c(1, 2)), expect)
-})
-
-test_that("`n` can be used with a multisplit", {
-  x <- array(1:8, dim = c(2, 4), dimnames = list(NULL))
-
-  expect <- list(
-    rray_subset(x, 1, 1:2),
-    rray_subset(x, 2, 1:2),
-    rray_subset(x, 1, 3:4),
-    rray_subset(x, 2, 3:4)
-  )
-
-  expect_equal(rray_split(x, axes = c(2, 1), n = c(2, 2)), expect)
 })
 
 test_that("dimension names are kept", {
@@ -69,7 +50,7 @@ test_that("dimension names are kept", {
     list(dim_names(x)[-1], dim_names(x)[-1])
   )
 
-  all_nms <- map(rray_split(x, c(4L, 3L)), dim_names)
+  all_nms <- map(rray_split(x, c(3L, 4L)), dim_names)
 
   expect_equal(
     all_nms[[1]],
@@ -103,21 +84,14 @@ test_that("axis is validated", {
   expect_error(rray_split(x, "hi"))
 })
 
-test_that("`n` must divide equally", {
-  x <- array(1:8, dim = c(2, 4), dimnames = list(NULL))
-  expect_error(rray_split(x, 1, n = 3), "does not result in equal division")
-})
-
 test_that("can split with NULL axes", {
   x <- array(1:8, dim = c(2, 4), dimnames = list(NULL))
-  expect_equal(rray_split(x), rray_split(x, axes = c(2, 1)))
-  expect_equal(rray_split(x, n = c(2, 2)), rray_split(x, axes = c(2, 1), n = c(2, 2)))
+  expect_equal(rray_split(x), rray_split(x, axes = c(1, 2)))
 })
 
 test_that("can split with integer(0) axis", {
   x <- array(1:8, dim = c(2, 4), dimnames = list(NULL))
   expect_equal(rray_split(x, axes = integer()), list(x))
-  expect_equal(rray_split(x, axes = integer(), n = integer()), list(x))
 })
 
 


### PR DESCRIPTION
- Rewrite `rray_split()` with faster C++ internals. A custom split function is used, rather than `xt::split()`. This has the advantage of being able to split over multiple axes at once, and I can handle the dim names as I go
- The `n` argument has been removed. I'm not sure how useful it will be in practice, and it would require more thought to handle it correctly.
- The order of splitting is now more intuitive. Rather than having to split in reverse order to split over multiple axes, you specify the axes in order.
- A few dim name functions have been partially rewritten at the C++ level. These will be firmed up soon.