### PR TITLE
Use immediate evaluation strategy in reducers

### DIFF
--- a/src/reducers.cpp
+++ b/src/reducers.cpp
@@ -2,6 +2,9 @@
 #include <dispatch.h>
 #include <tools/tools.h>
 
+// Required for xt::evaluation_strategy::immediate
+#include <xtensor/xarray.hpp>
+
 // -----------------------------------------------------------------------------
 
 #define DISPATCH_REDUCER(FUN, X, AXES)                         \
@@ -24,13 +27,13 @@ template <typename T>
 xt::rarray<double> rray__sum_impl(const xt::rarray<T>& x, Rcpp::RObject axes) {
 
   if (r_is_null(axes)) {
-    return xt::sum(x, xt::keep_dims);
+    return xt::sum(x, xt::keep_dims | xt::evaluation_strategy::immediate);
   }
 
   using size_vec = typename std::vector<std::size_t>;
   size_vec xt_axes = Rcpp::as<size_vec>(axes);
 
-  return xt::sum(x, xt_axes, xt::keep_dims);
+  return xt::sum(x, xt_axes, xt::keep_dims | xt::evaluation_strategy::immediate);
 }
 
 // [[Rcpp::export(rng = false)]]
@@ -44,13 +47,13 @@ template <typename T>
 xt::rarray<double> rray__prod_impl(const xt::rarray<T>& x, Rcpp::RObject axes) {
 
   if (r_is_null(axes)) {
-    return xt::prod(x, xt::keep_dims);
+    return xt::prod(x, xt::keep_dims | xt::evaluation_strategy::immediate);
   }
 
   using size_vec = typename std::vector<std::size_t>;
   size_vec xt_axes = Rcpp::as<size_vec>(axes);
 
-  return xt::prod(x, xt_axes, xt::keep_dims);
+  return xt::prod(x, xt_axes, xt::keep_dims | xt::evaluation_strategy::immediate);
 }
 
 // [[Rcpp::export(rng = false)]]
@@ -64,13 +67,13 @@ template <typename T>
 xt::rarray<double> rray__mean_impl(const xt::rarray<T>& x, Rcpp::RObject axes) {
 
   if (r_is_null(axes)) {
-    return xt::mean(x, xt::keep_dims);
+    return xt::mean(x, xt::keep_dims | xt::evaluation_strategy::immediate);
   }
 
   using size_vec = typename std::vector<std::size_t>;
   size_vec xt_axes = Rcpp::as<size_vec>(axes);
 
-  return xt::mean(x, xt_axes, xt::keep_dims);
+  return xt::mean(x, xt_axes, xt::keep_dims | xt::evaluation_strategy::immediate);
 }
 
 // [[Rcpp::export(rng = false)]]
@@ -202,7 +205,7 @@ Rcpp::RObject rray__max_impl(const xt::rarray<T>& x,
   }
 
   if (r_is_null(axes)) {
-    xt::rarray<T> xt_out = xt::amax(x, xt::keep_dims);
+    xt::rarray<T> xt_out = xt::amax(x, xt::keep_dims | xt::evaluation_strategy::immediate);
     Rcpp::RObject out = SEXP(xt_out);
     return out;
   }
@@ -210,7 +213,7 @@ Rcpp::RObject rray__max_impl(const xt::rarray<T>& x,
   using size_vec = typename std::vector<std::size_t>;
   size_vec xt_axes = Rcpp::as<size_vec>(axes);
 
-  xt::rarray<T> xt_out = xt::amax(x, xt_axes, xt::keep_dims);
+  xt::rarray<T> xt_out = xt::amax(x, xt_axes, xt::keep_dims | xt::evaluation_strategy::immediate);
   Rcpp::RObject out = SEXP(xt_out);
 
   return out;
@@ -233,7 +236,7 @@ Rcpp::RObject rray__min_impl(const xt::rarray<T>& x,
   }
 
   if (r_is_null(axes)) {
-    xt::rarray<T> xt_out = xt::amin(x, xt::keep_dims);
+    xt::rarray<T> xt_out = xt::amin(x, xt::keep_dims | xt::evaluation_strategy::immediate);
     Rcpp::RObject out = SEXP(xt_out);
     return out;
   }
@@ -241,7 +244,7 @@ Rcpp::RObject rray__min_impl(const xt::rarray<T>& x,
   using size_vec = typename std::vector<std::size_t>;
   size_vec xt_axes = Rcpp::as<size_vec>(axes);
 
-  xt::rarray<T> xt_out = xt::amin(x, xt_axes, xt::keep_dims);
+  xt::rarray<T> xt_out = xt::amin(x, xt_axes, xt::keep_dims | xt::evaluation_strategy::immediate);
   Rcpp::RObject out = SEXP(xt_out);
 
   return out;


### PR DESCRIPTION
Provides a significant speed boost, now that I realized what includes are needed.

before:

``` r
library(rray)
set.seed(92136)
n <- 1e4 # build n x n test matrix
x <- matrix(rnorm(n), 1, n)
x <- crossprod(x, x) # symmetric

bench::mark(rowSums(x))
#> # A tibble: 1 x 10
#>   expression   min  mean median   max `itr/sec` mem_alloc  n_gc n_itr
#>   <chr>      <bch> <bch> <bch:> <bch>     <dbl> <bch:byt> <dbl> <int>
#> 1 rowSums(x) 131ms 134ms  133ms 140ms      7.46    78.2KB     0     4
#> # … with 1 more variable: total_time <bch:tm>
bench::mark(rray_sum(x, 2))
#> # A tibble: 1 x 10
#>   expression   min  mean median   max `itr/sec` mem_alloc  n_gc n_itr
#>   <chr>      <bch> <bch> <bch:> <bch>     <dbl> <bch:byt> <dbl> <int>
#> 1 rray_sum(… 936ms 936ms  936ms 936ms      1.07    5.32MB     0     1
#> # … with 1 more variable: total_time <bch:tm>

bench::mark(colSums(x))
#> # A tibble: 1 x 10
#>   expression    min   mean median    max `itr/sec` mem_alloc  n_gc n_itr
#>   <chr>      <bch:> <bch:> <bch:> <bch:>     <dbl> <bch:byt> <dbl> <int>
#> 1 colSums(x) 71.6ms 74.8ms 72.9ms 86.8ms      13.4    78.2KB     0     7
#> # … with 1 more variable: total_time <bch:tm>
bench::mark(rray_sum(x, 1))
#> # A tibble: 1 x 10
#>   expression   min  mean median   max `itr/sec` mem_alloc  n_gc n_itr
#>   <chr>      <bch> <bch> <bch:> <bch>     <dbl> <bch:byt> <dbl> <int>
#> 1 rray_sum(… 101ms 109ms  111ms 121ms      9.13    78.2KB     0     5
#> # … with 1 more variable: total_time <bch:tm>
```

after:

``` r
library(rray)
set.seed(92136)
n <- 1e4 # build n x n test matrix
x <- matrix(rnorm(n), 1, n)
x <- crossprod(x, x) # symmetric

bench::mark(rowSums(x))
#> # A tibble: 1 x 10
#>   expression   min  mean median   max `itr/sec` mem_alloc  n_gc n_itr
#>   <chr>      <bch> <bch> <bch:> <bch>     <dbl> <bch:byt> <dbl> <int>
#> 1 rowSums(x) 132ms 134ms  134ms 135ms      7.49    78.2KB     0     4
#> # … with 1 more variable: total_time <bch:tm>
bench::mark(rray_sum(x, 2))
#> # A tibble: 1 x 10
#>   expression    min   mean median    max `itr/sec` mem_alloc  n_gc n_itr
#>   <chr>      <bch:> <bch:> <bch:> <bch:>     <dbl> <bch:byt> <dbl> <int>
#> 1 rray_sum(… 55.6ms 56.5ms 56.5ms 57.5ms      17.7    5.32MB     0     9
#> # … with 1 more variable: total_time <bch:tm>

bench::mark(colSums(x))
#> # A tibble: 1 x 10
#>   expression    min   mean median    max `itr/sec` mem_alloc  n_gc n_itr
#>   <chr>      <bch:> <bch:> <bch:> <bch:>     <dbl> <bch:byt> <dbl> <int>
#> 1 colSums(x) 71.5ms 76.2ms 75.6ms 82.1ms      13.1    78.2KB     0     7
#> # … with 1 more variable: total_time <bch:tm>
bench::mark(rray_sum(x, 1))
#> # A tibble: 1 x 10
#>   expression    min  mean median   max `itr/sec` mem_alloc  n_gc n_itr
#>   <chr>      <bch:> <bch> <bch:> <bch>     <dbl> <bch:byt> <dbl> <int>
#> 1 rray_sum(… 93.6ms  99ms 96.5ms 113ms      10.1    78.2KB     0     6
#> # … with 1 more variable: total_time <bch:tm>
```