### PR TITLE
Use `noalias()` in subset-assignment

### DIFF
--- a/R/yank-assign.R
+++ b/R/yank-assign.R
@@ -21,10 +21,10 @@ rray_yank_assign <- function(x, i, value) {
   value <- vec_cast_inner(value, x)
 
   # TODO
-  if (is.integer(i) && is_any_na_int(i)) {
+  if (is.integer(i) && is_any_na_int(list(i))) {
     abort("`NA` indices are not yet supported.")
   }
-  else if (is.logical(i) && is_any_na_int(as.integer(i))) {
+  else if (is.logical(i) && is_any_na_int(list(as.integer(i)))) {
     abort("`NA` indices are not yet supported.")
   }
 

--- a/R/yank.R
+++ b/R/yank.R
@@ -99,10 +99,10 @@ rray_yank_impl <- function(x, i) {
   i <- as_yank_indexer(i, x)
 
   # TODO
-  if (is.integer(i) && is_any_na_int(i)) {
+  if (is.integer(i) && is_any_na_int(list(i))) {
     abort("`NA` indices are not yet supported.")
   }
-  else if (is.logical(i) && is_any_na_int(as.integer(i))) {
+  else if (is.logical(i) && is_any_na_int(list(as.integer(i)))) {
     abort("`NA` indices are not yet supported.")
   }
 

--- a/inst/include/tools/template-utils.h
+++ b/inst/include/tools/template-utils.h
@@ -75,7 +75,7 @@ inline auto rray__increase_dims_view2(const xt::rarray<T>& x,
 // Validate that `x` is immediately broadcastable to the dimensions of `to`
 
 template <class E1, class E2>
-void rray__validate_broadcastable_to(E1 x, E2 to) {
+void rray__validate_broadcastable_to(E1&& x, E2&& to) {
   auto x_shape = x.shape();
   Rcpp::IntegerVector x_dim(x_shape.begin(), x_shape.end());
 

--- a/src/subset-assign.cpp
+++ b/src/subset-assign.cpp
@@ -6,6 +6,9 @@
 // Required for the assignment step
 #include <xtensor/xarray.hpp>
 
+// For assignment speed
+#include <xtensor/xnoalias.hpp>
+
 // xtensor can't handle assigning to a requested dimension of 0
 // i.e. this crashes) x[0, 1] <- 99
 // this should always be a no-op so we just check for it and return x
@@ -47,13 +50,13 @@ Rcpp::RObject rray__subset_assign_impl(const xt::rarray<T>& x,
     xt::xstrided_slice_vector sv = build_strided_slice_vector(indexer);
     auto xt_out_subset_view = xt::strided_view(out, sv);
     rray__validate_broadcastable_to(value_view, xt_out_subset_view);
-    xt_out_subset_view = value_view;
+    xt::noalias(xt_out_subset_view) = value_view;
   }
   else {
     xt::xdynamic_slice_vector sv = build_dynamic_slice_vector(indexer);
     auto xt_out_subset_view = xt::dynamic_view(out, sv);
     rray__validate_broadcastable_to(value_view, xt_out_subset_view);
-    xt_out_subset_view = value_view;
+    xt::noalias(xt_out_subset_view) = value_view;
   }
 
   return Rcpp::as<Rcpp::RObject>(out);


### PR DESCRIPTION
Closes #184 

Big speed boost from this when `value` is a large object because `value` won't have a temporary copy of it made.

Before adding `noalias()`:

``` r
library(rray)

x <- matrix(1:1000000 + 0L, dimnames = list(NULL, NULL))

value <- 1:1000000 + 1L

bench::mark(
  rray_subset_assign(x, , 1, value = value),
  `[<-`(x, , 1, value = value),
  {x[, 1] <- value; x},
  iterations = 1000
)
#> # A tibble: 3 x 10
#>   expression    min   mean median     max `itr/sec` mem_alloc  n_gc n_itr
#>   <chr>      <bch:> <bch:> <bch:> <bch:t>     <dbl> <bch:byt> <dbl> <int>
#> 1 rray_subs… 6.56ms 8.26ms 8.29ms 13.82ms      121.    4.11MB   149   851
#> 2 `[<-`(x, … 1.95ms 2.44ms 2.41ms  3.81ms      410.    7.63MB   325   675
#> 3 {...       1.34ms 1.62ms 1.61ms  2.36ms      616.    7.63MB   161   839
#> # … with 1 more variable: total_time <bch:tm>
```

<sup>Created on 2019-06-12 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

After adding `noalias()`:

``` r
library(rray)

x <- matrix(1:1000000 + 0L, dimnames = list(NULL, NULL))

value <- 1:1000000 + 1L

bench::mark(
  rray_subset_assign(x, , 1, value = value),
  `[<-`(x, , 1, value = value),
  {x[, 1] <- value; x},
  iterations = 1000
)
#> # A tibble: 3 x 10
#>   expression      min   mean median    max `itr/sec` mem_alloc  n_gc n_itr
#>   <chr>      <bch:tm> <bch:> <bch:> <bch:>     <dbl> <bch:byt> <dbl> <int>
#> 1 rray_subs… 815.31µs 1.18ms 1.08ms 4.58ms      845.    4.11MB   149   851
#> 2 `[<-`(x, …      2ms 2.46ms 2.42ms 5.04ms      406.    7.63MB   325   675
#> 3 {...         1.36ms 1.65ms 1.64ms 2.61ms      605.    7.63MB   161   839
#> # … with 1 more variable: total_time <bch:tm>
```

<sup>Created on 2019-06-12 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

Loving `noalias()` @wolfv